### PR TITLE
Adding dependancy to Test project for Dependabot

### DIFF
--- a/src/NServiceBus.Persistence.DynamoDB.Tests/NServiceBus.Persistence.DynamoDB.Tests.csproj
+++ b/src/NServiceBus.Persistence.DynamoDB.Tests/NServiceBus.Persistence.DynamoDB.Tests.csproj
@@ -11,6 +11,8 @@
     <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
     <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.3.52" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <!-- DO NOT REMOVE Newtonsoft.Json, it is added so that dependabot knows about version changes-->
+    <PackageReference Include="Newtonsoft.json" Version="13.0.1" />
     <PackageReference Include="NServiceBus" Version="8.0.0-beta.3" />
     <PackageReference Include="NServiceBus.Testing" Version="8.0.0-beta.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />


### PR DESCRIPTION
Adding dependencies to the Test project so Dependabot will keep track of them and notify use of issues