### PR TITLE
Additional outbox tests

### DIFF
--- a/src/NServiceBus.Persistence.DynamoDB.PersistenceTests/.editorconfig
+++ b/src/NServiceBus.Persistence.DynamoDB.PersistenceTests/.editorconfig
@@ -1,0 +1,12 @@
+[*.cs]
+
+# Justification: Test project
+dotnet_diagnostic.CA2007.severity = none
+
+# Justification: Tests don't support cancellation and don't need to forward IMessageHandlerContext.CancellationToken
+dotnet_diagnostic.NSB0002.severity = suggestion
+dotnet_diagnostic.PS0018.severity = suggestion
+dotnet_diagnostic.PS0013.severity = suggestion
+
+# Persistence library doesn't need saga analyzers
+dotnet_diagnostic.NSB0004.severity = none

--- a/src/NServiceBus.Persistence.DynamoDB.PersistenceTests/OutboxTests.cs
+++ b/src/NServiceBus.Persistence.DynamoDB.PersistenceTests/OutboxTests.cs
@@ -40,7 +40,7 @@
             ContextBag contextBag = configuration.GetContextBagForOutbox();
 
             var r = new Random();
-            byte[] payload = new byte[500_000]; // 4 KB is the item size limit
+            byte[] payload = new byte[500_000]; // 400 KB is the item size limit
             r.NextBytes(payload);
 
             var transportOperations = new TransportOperation[]
@@ -66,7 +66,7 @@
             ContextBag contextBag = configuration.GetContextBagForOutbox();
 
             var r = new Random();
-            byte[] payload = new byte[300_000]; // 4 KB is the item size limit
+            byte[] payload = new byte[300_000]; // 400 KB is the item size limit
             r.NextBytes(payload);
 
             // Generate total transaction payload > 4MB
@@ -118,7 +118,7 @@
             ContextBag contextBag = configuration.GetContextBagForOutbox();
 
             var r = new Random();
-            byte[] payload = new byte[100_000]; // 4 KB is the item size limit
+            byte[] payload = new byte[100_000]; // 400 KB is the item size limit
             r.NextBytes(payload);
 
             // Query size limit is 1MB

--- a/src/NServiceBus.Persistence.DynamoDB.PersistenceTests/OutboxTests.cs
+++ b/src/NServiceBus.Persistence.DynamoDB.PersistenceTests/OutboxTests.cs
@@ -55,8 +55,7 @@
                 var outboxMessage = new OutboxMessage(Guid.NewGuid().ToString(), transportOperations);
                 await configuration.OutboxStorage.Store(outboxMessage, transaction, contextBag);
 
-                //TODO what exception should we assert?
-                Assert.ThrowsAsync<Exception>(() => transaction.Commit());
+                Assert.ThrowsAsync<AmazonDynamoDBException>(() => transaction.Commit());
             }
         }
 
@@ -83,8 +82,7 @@
                 var outboxMessage = new OutboxMessage(Guid.NewGuid().ToString(), transportOperations);
                 await configuration.OutboxStorage.Store(outboxMessage, transaction, contextBag);
 
-                //TODO what exception should we assert?
-                Assert.ThrowsAsync<Exception>(() => transaction.Commit());
+                Assert.ThrowsAsync<AmazonDynamoDBException>(() => transaction.Commit());
             }
         }
 
@@ -103,10 +101,10 @@
             {
 
                 var outboxMessage = new OutboxMessage(Guid.NewGuid().ToString(), transportOperations);
-                await configuration.OutboxStorage.Store(outboxMessage, transaction, contextBag);
 
-                //TODO what exception should we assert?
-                Assert.ThrowsAsync<Exception>(() => transaction.Commit());
+                Assert.ThrowsAsync<AmazonDynamoDBException>(() => configuration.OutboxStorage.Store(outboxMessage, transaction, contextBag));
+
+                // already throws at store, no need to commit
             }
         }
 

--- a/src/NServiceBus.Persistence.DynamoDB.PersistenceTests/OutboxTests.cs
+++ b/src/NServiceBus.Persistence.DynamoDB.PersistenceTests/OutboxTests.cs
@@ -3,6 +3,7 @@
     using System.Threading.Tasks;
     using System;
     using System.Collections.Generic;
+    using Amazon.DynamoDBv2;
     using Extensibility;
     using NServiceBus.Outbox;
     using NUnit.Framework;
@@ -106,7 +107,6 @@
                 await configuration.OutboxStorage.Store(outboxMessage, transaction, contextBag);
 
                 //TODO what exception should we assert?
-                //TODO currently fails at 25 but shouldn't it be 100? https://aws.amazon.com/about-aws/whats-new/2022/09/amazon-dynamodb-supports-100-actions-per-transaction/
                 Assert.ThrowsAsync<Exception>(() => transaction.Commit());
             }
         }

--- a/src/NServiceBus.Persistence.DynamoDB.PersistenceTests/OutboxTests.cs
+++ b/src/NServiceBus.Persistence.DynamoDB.PersistenceTests/OutboxTests.cs
@@ -96,8 +96,7 @@
             var transportOperations = new TransportOperation[100]; // 100 items is the transaction limit, we generate n+1 items in the persister
             for (int i = 0; i < transportOperations.Length; i++)
             {
-                transportOperations[i] = new TransportOperation(Guid.NewGuid().ToString(), new DispatchProperties(),
-                    new ReadOnlyMemory<byte>(), new Dictionary<string, string>());
+                transportOperations[i] = new TransportOperation(Guid.NewGuid().ToString(), new DispatchProperties(), ReadOnlyMemory<byte>.Empty, new Dictionary<string, string>());
             }
 
             using (var transaction = await configuration.OutboxStorage.BeginTransaction(contextBag))

--- a/src/NServiceBus.Persistence.DynamoDB.PersistenceTests/OutboxTests.cs
+++ b/src/NServiceBus.Persistence.DynamoDB.PersistenceTests/OutboxTests.cs
@@ -1,0 +1,144 @@
+﻿namespace NServiceBus.PersistenceTesting
+{
+    using System.Threading.Tasks;
+    using System;
+    using System.Collections.Generic;
+    using Extensibility;
+    using NServiceBus.Outbox;
+    using NUnit.Framework;
+    using Transport;
+    using TransportOperation = NServiceBus.Outbox.TransportOperation;
+
+    [TestFixtureSource(typeof(PersistenceTestsConfiguration), nameof(PersistenceTestsConfiguration.OutboxVariants))]
+    public class OutboxTests
+    {
+        readonly TestVariant param;
+        PersistenceTestsConfiguration configuration;
+
+        public OutboxTests(TestVariant param)
+        {
+            this.param = param.DeepCopy();
+        }
+
+        [OneTimeSetUp]
+        public async Task OneTimeSetUp()
+        {
+            configuration = new PersistenceTestsConfiguration(param);
+            await configuration.Configure();
+        }
+
+        [OneTimeTearDown]
+        public async Task OneTimeTearDown()
+        {
+            await configuration.Cleanup();
+        }
+
+        [Test]
+        public async Task Should_fail_when_outbox_item_beyond_size_limit()
+        {
+            ContextBag contextBag = configuration.GetContextBagForOutbox();
+
+            var r = new Random();
+            byte[] payload = new byte[500_000]; // 4 KB is the item size limit
+            r.NextBytes(payload);
+
+            var transportOperations = new TransportOperation[]
+            {
+                new(Guid.NewGuid().ToString(), new DispatchProperties(),
+                    payload, new Dictionary<string, string>())
+            };
+
+            using (var transaction = await configuration.OutboxStorage.BeginTransaction(contextBag))
+            {
+
+                var outboxMessage = new OutboxMessage(Guid.NewGuid().ToString(), transportOperations);
+                await configuration.OutboxStorage.Store(outboxMessage, transaction, contextBag);
+
+                //TODO what exception should we assert?
+                Assert.ThrowsAsync<Exception>(() => transaction.Commit());
+            }
+        }
+
+        [Test]
+        public async Task Should_fail_when_outbox_operations_beyond_size_limit()
+        {
+            ContextBag contextBag = configuration.GetContextBagForOutbox();
+
+            var r = new Random();
+            byte[] payload = new byte[300_000]; // 4 KB is the item size limit
+            r.NextBytes(payload);
+
+            // Generate total transaction payload > 4MB
+            var transportOperations = new TransportOperation[15];
+            for (int i = 0; i < transportOperations.Length; i++)
+            {
+                transportOperations[i] = new TransportOperation(Guid.NewGuid().ToString(), new DispatchProperties(),
+                    payload, new Dictionary<string, string>());
+            }
+
+            using (var transaction = await configuration.OutboxStorage.BeginTransaction(contextBag))
+            {
+
+                var outboxMessage = new OutboxMessage(Guid.NewGuid().ToString(), transportOperations);
+                await configuration.OutboxStorage.Store(outboxMessage, transaction, contextBag);
+
+                //TODO what exception should we assert?
+                Assert.ThrowsAsync<Exception>(() => transaction.Commit());
+            }
+        }
+
+        [Test]
+        public async Task Should_fail_when_outbox_operations_beyond_transaction_item_limit()
+        {
+            ContextBag contextBag = configuration.GetContextBagForOutbox();
+
+            var transportOperations = new TransportOperation[100]; // 100 items is the transaction limit, we generate n+1 items in the persister
+            for (int i = 0; i < transportOperations.Length; i++)
+            {
+                transportOperations[i] = new TransportOperation(Guid.NewGuid().ToString(), new DispatchProperties(),
+                    new ReadOnlyMemory<byte>(), new Dictionary<string, string>());
+            }
+
+            using (var transaction = await configuration.OutboxStorage.BeginTransaction(contextBag))
+            {
+
+                var outboxMessage = new OutboxMessage(Guid.NewGuid().ToString(), transportOperations);
+                await configuration.OutboxStorage.Store(outboxMessage, transaction, contextBag);
+
+                //TODO what exception should we assert?
+                //TODO currently fails at 25 but shouldn't it be 100? https://aws.amazon.com/about-aws/whats-new/2022/09/amazon-dynamodb-supports-100-actions-per-transaction/
+                Assert.ThrowsAsync<Exception>(() => transaction.Commit());
+            }
+        }
+
+        [Test]
+        public async Task Should_fetch_all_outbox_messages_when_total_size_beyond_single_query_limit()
+        {
+            var incomingMessageId = Guid.NewGuid().ToString();
+            ContextBag contextBag = configuration.GetContextBagForOutbox();
+
+            var r = new Random();
+            byte[] payload = new byte[100_000]; // 4 KB is the item size limit
+            r.NextBytes(payload);
+
+            // Query size limit is 1MB
+            var transportOperations = new TransportOperation[20];
+            for (int i = 0; i < transportOperations.Length; i++)
+            {
+                transportOperations[i] = new TransportOperation(Guid.NewGuid().ToString(), new DispatchProperties(),
+                    payload, new Dictionary<string, string>());
+            }
+
+            using (var transaction = await configuration.OutboxStorage.BeginTransaction(contextBag))
+            {
+                var outboxMessage = new OutboxMessage(incomingMessageId, transportOperations);
+                await configuration.OutboxStorage.Store(outboxMessage, transaction, contextBag);
+
+                await transaction.Commit();
+            }
+
+            var result = await configuration.OutboxStorage.Get(incomingMessageId, configuration.GetContextBagForOutbox());
+            Assert.AreEqual(transportOperations.Length, result.TransportOperations.Length);
+        }
+    }
+}

--- a/src/NServiceBus.Persistence.DynamoDB/Outbox/OutboxPersister.cs
+++ b/src/NServiceBus.Persistence.DynamoDB/Outbox/OutboxPersister.cs
@@ -41,8 +41,7 @@
             {
                 var queryRequest = new QueryRequest
                 {
-                    ConsistentRead =
-                        false, //TODO: Do we need to check the integrity of the read by counting the operations?
+                    ConsistentRead = true,
                     KeyConditionExpression = "#PK = :incomingId",
                     ExclusiveStartKey = response?.LastEvaluatedKey,
                     ExpressionAttributeNames = new Dictionary<string, string>

--- a/src/NServiceBus.Persistence.DynamoDB/SynchronizedStorage/StorageSession.cs
+++ b/src/NServiceBus.Persistence.DynamoDB/SynchronizedStorage/StorageSession.cs
@@ -31,6 +31,7 @@
 
         void CheckCapacity()
         {
+            // The error on exceeded transaction items raised by the service is extremely convoluted and hard to understand. Until this is improved, we prevent an invalid request on the client side and throw a more meaningful exception to help users understand the limitations.
             if (batch.Count > 100)
             {
                 throw new AmazonDynamoDBException(

--- a/src/NServiceBus.Persistence.DynamoDB/SynchronizedStorage/StorageSession.cs
+++ b/src/NServiceBus.Persistence.DynamoDB/SynchronizedStorage/StorageSession.cs
@@ -31,12 +31,13 @@
 
         void CheckCapacity()
         {
-            // TODO: 25 should be a constant probably in the settings
-            if (batch.Count > 25)
-            {
-                throw new Exception(
-                    "Transactional writes are limited to 25 items. Each saga counts as one item. Outbox, if enabled, counts as one item plus one additional item for each outgoing message.");
-            }
+            // TODO: Should we really capture this on the client side? Allows for better exception messages though.
+            // TODO: 100 should be a constant probably in the settings
+            //if (batch.Count > 100)
+            //{
+            //    throw new Exception(
+            //        "Transactional writes are limited to 100 items. Each saga counts as one item. Outbox, if enabled, counts as one item plus one additional item for each outgoing message.");
+            //}
         }
 
         public async Task Commit(CancellationToken cancellationToken = default)

--- a/src/NServiceBus.Persistence.DynamoDB/SynchronizedStorage/StorageSession.cs
+++ b/src/NServiceBus.Persistence.DynamoDB/SynchronizedStorage/StorageSession.cs
@@ -31,13 +31,11 @@
 
         void CheckCapacity()
         {
-            // TODO: Should we really capture this on the client side? Allows for better exception messages though.
-            // TODO: 100 should be a constant probably in the settings
-            //if (batch.Count > 100)
-            //{
-            //    throw new Exception(
-            //        "Transactional writes are limited to 100 items. Each saga counts as one item. Outbox, if enabled, counts as one item plus one additional item for each outgoing message.");
-            //}
+            if (batch.Count > 100)
+            {
+                throw new AmazonDynamoDBException(
+                    "Transactional writes are limited to 100 items. Each saga counts as one item. Outbox, if enabled, counts as one item plus one additional item for each outgoing message.");
+            }
         }
 
         public async Task Commit(CancellationToken cancellationToken = default)


### PR DESCRIPTION
Adds a few extra tests that are focused on testing the expected behavior when reaching the dynamo DB operation limits.

Relevant limits being tested:

* Transactions are limited to 4MB in total size and 25/100 operations in the transactional batch.
* Collection fetches are limited to 1MB in total size per operation
* A single item is limited to 4KB total size

The tests are currently failing because the assertions aren't expecting on the actual exception type.