### PR TITLE
[Spike] Tag tables created by installer

### DIFF
--- a/src/NServiceBus.Persistence.DynamoDB.AcceptanceTests/SetupFixture.cs
+++ b/src/NServiceBus.Persistence.DynamoDB.AcceptanceTests/SetupFixture.cs
@@ -1,9 +1,11 @@
 ﻿namespace NServiceBus.AcceptanceTests
 {
     using System;
+    using System.Collections.Generic;
     using System.IO;
     using System.Threading.Tasks;
     using Amazon.DynamoDBv2;
+    using Amazon.DynamoDBv2.Model;
     using Amazon.Runtime;
     using NUnit.Framework;
     using Persistence.DynamoDB;
@@ -22,7 +24,7 @@
 
             DynamoDBClient = client;
 
-            var installer = new Installer(DynamoDBClient);
+            var installer = new Installer(DynamoDBClient, new List<Tag> { new Tag { Key = "Tests", Value = "Acceptance tests" } });
 
             await installer.CreateOutboxTableIfNotExists(new OutboxPersistenceConfiguration { TableName = TableName });
             await installer.CreateSagaTableIfNotExists(new SagaPersistenceConfiguration { TableName = TableName });

--- a/src/NServiceBus.Persistence.DynamoDB.PersistenceTests/SetupFixture.cs
+++ b/src/NServiceBus.Persistence.DynamoDB.PersistenceTests/SetupFixture.cs
@@ -1,10 +1,12 @@
 ﻿namespace NServiceBus.PersistenceTesting
 {
     using System;
+    using System.Collections.Generic;
     using System.IO;
     using System.Threading;
     using System.Threading.Tasks;
     using Amazon.DynamoDBv2;
+    using Amazon.DynamoDBv2.Model;
     using Amazon.Runtime;
     using NUnit.Framework;
     using Persistence.DynamoDB;
@@ -35,7 +37,7 @@
                 SortKeyName = Guid.NewGuid().ToString("N") + "SK"
             };
 
-            var installer = new Installer(DynamoDBClient);
+            var installer = new Installer(DynamoDBClient, new List<Tag> { new() { Key = "Tests", Value = "PersistenceTests" } });
 
             await installer.CreateOutboxTableIfNotExists(OutboxConfiguration, CancellationToken.None).ConfigureAwait(false);
             await installer.CreateSagaTableIfNotExists(SagaConfiguration, CancellationToken.None).ConfigureAwait(false);

--- a/src/NServiceBus.Persistence.DynamoDB.Tests/InstallerTests.cs
+++ b/src/NServiceBus.Persistence.DynamoDB.Tests/InstallerTests.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.Persistence.DynamoDB.Tests
 {
     using System;
+    using System.Collections.Generic;
     using System.Linq;
     using System.Threading;
     using Amazon.DynamoDBv2.Model;
@@ -35,7 +36,7 @@
                 PartitionKeyName = Guid.NewGuid().ToString("N"),
                 SortKeyName = Guid.NewGuid().ToString("N")
             };
-            installer = new Installer(dynamoClient);
+            installer = new Installer(dynamoClient, new List<Tag> { new() { Key = "Tests", Value = "InstallerTests" } });
         }
 
         class SagaInstallationTests : InstallerTests


### PR DESCRIPTION
Small spike to try out an idea to tag all tables created by test infrastructure.

This might be an alternative approach to handle the cleanup-logic when running tests. Unfortunately, there doesn't seem to be an easy way to find all tables with specific tags. We'd have to get all tables and then look at each table in detail to read the tags.