### PR TITLE
Switch to Particular.Approvals latest

### DIFF
--- a/src/NServiceBus.Persistence.DynamoDB.PersistenceTests/NServiceBus.Persistence.DynamoDB.PersistenceTests.csproj
+++ b/src/NServiceBus.Persistence.DynamoDB.PersistenceTests/NServiceBus.Persistence.DynamoDB.PersistenceTests.csproj
@@ -19,11 +19,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Particular.Approvals" Version="0.3.0" />
-    <PackageReference Include="PublicApiGenerator" Version="11.0.0" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\NServiceBus.Persistence.DynamoDB\NServiceBus.Persistence.DynamoDB.csproj" />
   </ItemGroup>
   

--- a/src/NServiceBus.Persistence.DynamoDB.Tests/NServiceBus.Persistence.DynamoDB.Tests.csproj
+++ b/src/NServiceBus.Persistence.DynamoDB.Tests/NServiceBus.Persistence.DynamoDB.Tests.csproj
@@ -11,8 +11,6 @@
     <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
     <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.102.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <!-- DO NOT REMOVE Newtonsoft.Json: Added due to an implicit dependency from Particular.Approvals. This can be removed once Particular.Approvals has been updated to 13.0.3 -->
-    <PackageReference Include="Newtonsoft.json" Version="13.0.3" />
     <PackageReference Include="NServiceBus" Version="8.0.3" />
     <PackageReference Include="NServiceBus.Testing" Version="8.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
@@ -20,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Particular.Approvals" Version="0.3.0" />
+    <PackageReference Include="Particular.Approvals" Version="0.4.0" />
     <PackageReference Include="PublicApiGenerator" Version="11.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
With Particular.Approvals 0.4.0 we can now get rid of the `Newtonsoft.Json` dependency