### PR TITLE
Add test for TestableDynamoDBSynchronizedStorageSession

### DIFF
--- a/src/NServiceBus.Persistence.DynamoDB.Tests/TestableDynamoDBSynchronizedStorageSessionTests.cs
+++ b/src/NServiceBus.Persistence.DynamoDB.Tests/TestableDynamoDBSynchronizedStorageSessionTests.cs
@@ -1,0 +1,43 @@
+﻿namespace NServiceBus.Persistence.DynamoDB.Tests
+{
+    using System.Threading.Tasks;
+    using Amazon.DynamoDBv2.Model;
+    using NServiceBus.Testing;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class TestableDynamoDBSynchronizedStorageSessionTests
+    {
+        [Test]
+        public async Task Should_be_usable_with_testable_handler_context()
+        {
+            var handler = new Handler();
+            var testableSession = new TestableDynamoDBSynchronizedStorageSession();
+            await handler.Handle(new Handler.MyMessage(), new TestableMessageHandlerContext
+            {
+                SynchronizedStorageSession = testableSession
+            });
+
+            Assert.That(testableSession.TransactWriteItems, Has.Count.EqualTo(3));
+        }
+
+        class Handler : IHandleMessages<Handler.MyMessage>
+        {
+            public Task Handle(MyMessage message, IMessageHandlerContext context)
+            {
+                var session = context.SynchronizedStorageSession.DynamoDBPersistenceSession();
+
+                session.Add(new TransactWriteItem());
+                session.AddRange(new[] { new TransactWriteItem(), new TransactWriteItem() });
+
+                return Task.CompletedTask;
+            }
+
+
+            public class MyMessage
+            {
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
A small test that verifies that the storage session can be used with the testable handler context and used via the extension method