### PR TITLE
Concurrency assertions

### DIFF
--- a/src/NServiceBus.Persistence.DynamoDB.AcceptanceTests/NServiceBus.Persistence.DynamoDB.AcceptanceTests.csproj
+++ b/src/NServiceBus.Persistence.DynamoDB.AcceptanceTests/NServiceBus.Persistence.DynamoDB.AcceptanceTests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.102.12" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.102.15" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="NServiceBus.Testing" Version="8.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />

--- a/src/NServiceBus.Persistence.DynamoDB.PersistenceTests/NServiceBus.Persistence.DynamoDB.PersistenceTests.csproj
+++ b/src/NServiceBus.Persistence.DynamoDB.PersistenceTests/NServiceBus.Persistence.DynamoDB.PersistenceTests.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.102.12" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.102.15" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="NServiceBus" Version="8.0.3" />
     <PackageReference Include="NServiceBus.Testing" Version="8.0.1" />

--- a/src/NServiceBus.Persistence.DynamoDB.PessimisticLock.AcceptanceTests/NServiceBus.Persistence.DynamoDB.PessimisticLock.AcceptanceTests.csproj
+++ b/src/NServiceBus.Persistence.DynamoDB.PessimisticLock.AcceptanceTests/NServiceBus.Persistence.DynamoDB.PessimisticLock.AcceptanceTests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.102.12" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.102.15" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="NServiceBus.Testing" Version="8.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />

--- a/src/NServiceBus.Persistence.DynamoDB.Tests/NServiceBus.Persistence.DynamoDB.Tests.csproj
+++ b/src/NServiceBus.Persistence.DynamoDB.Tests/NServiceBus.Persistence.DynamoDB.Tests.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.102.12" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.102.15" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="NServiceBus" Version="8.0.3" />
     <PackageReference Include="NServiceBus.Testing" Version="8.0.1" />


### PR DESCRIPTION
Attempt to avoid occasionally failing tests as they occurred in https://github.com/Particular/NServiceBus.Persistence.DynamoDB/pull/241 by using a mechanism that only ensures order without relying on a clock.