### PR TITLE
Bypass serialization for MemoryStreams and MemoryStreamSets

### DIFF
--- a/src/NServiceBus.Persistence.DynamoDB/Serialization/HashSetMemoryStreamConverter.cs
+++ b/src/NServiceBus.Persistence.DynamoDB/Serialization/HashSetMemoryStreamConverter.cs
@@ -95,7 +95,8 @@ namespace NServiceBus.Persistence.DynamoDB
             {
                 foreach (var streamElement in innerElement.EnumerateObject())
                 {
-                    memoryStreams.Add(new MemoryStream(streamElement.Value.GetBytesFromBase64()));
+                    _ = MemoryStreamConverter.TryExtract(streamElement, out var stream);
+                    memoryStreams.Add(stream);
                 }
             }
             return true;

--- a/src/NServiceBus.Persistence.DynamoDB/Serialization/HashSetStringConverter.cs
+++ b/src/NServiceBus.Persistence.DynamoDB/Serialization/HashSetStringConverter.cs
@@ -30,7 +30,7 @@ namespace NServiceBus.Persistence.DynamoDB
         sealed class SetConverter<TSet> : JsonConverter<TSet> where TSet : ISet<string>
         {
             public SetConverter(JsonSerializerOptions options)
-                => optionsWithoutHashSetOfNumberConverter = options.FromWithout<HashSetStringConverter>();
+                => optionsWithoutHashSetStringConverter = options.FromWithout<HashSetStringConverter>();
 
             public override TSet? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
             {
@@ -57,7 +57,7 @@ namespace NServiceBus.Persistence.DynamoDB
                     throw new JsonException();
                 }
 
-                var set = JsonSerializer.Deserialize<TSet>(ref reader, optionsWithoutHashSetOfNumberConverter);
+                var set = JsonSerializer.Deserialize<TSet>(ref reader, optionsWithoutHashSetStringConverter);
 
                 reader.Read();
 
@@ -72,11 +72,11 @@ namespace NServiceBus.Persistence.DynamoDB
             {
                 writer.WriteStartObject();
                 writer.WritePropertyName(PropertyName);
-                JsonSerializer.Serialize(writer, value, optionsWithoutHashSetOfNumberConverter);
+                JsonSerializer.Serialize(writer, value, optionsWithoutHashSetStringConverter);
                 writer.WriteEndObject();
             }
 
-            readonly JsonSerializerOptions optionsWithoutHashSetOfNumberConverter;
+            readonly JsonSerializerOptions optionsWithoutHashSetStringConverter;
         }
 
         public static bool TryExtract(JsonProperty property, out List<string?>? strings)


### PR DESCRIPTION
This avoids expensive Base64 encoding of the memory streams by storing them in a map and getting them out again. The intermediate format simply contains the key to the map. The map is stored as a `ThreadLocal` to make sure it is cleared under all circumstances; otherwise the mapper might indefinitely retain memory. 

The code is written in a way that the tracking field is only accessed in the code path where it is needed so that we don't create unnecessary dictionaries.