### PR TITLE
Support for custom serialization settings

### DIFF
--- a/src/NServiceBus.Persistence.DynamoDB.AcceptanceTests/NServiceBus.Persistence.DynamoDB.AcceptanceTests.csproj
+++ b/src/NServiceBus.Persistence.DynamoDB.AcceptanceTests/NServiceBus.Persistence.DynamoDB.AcceptanceTests.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net472;net6.0;net7.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NServiceBusTests.snk</AssemblyOriginatorKeyFile>
+    <LangVersion>10</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.Persistence.DynamoDB.AcceptanceTests/When_using_custom_serialization_options.cs
+++ b/src/NServiceBus.Persistence.DynamoDB.AcceptanceTests/When_using_custom_serialization_options.cs
@@ -1,0 +1,141 @@
+namespace NServiceBus.AcceptanceTests
+{
+    using System;
+    using System.IO;
+    using System.Text;
+    using System.Text.Json;
+    using System.Text.Json.Serialization;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NUnit.Framework;
+    using Persistence.DynamoDB;
+
+    public class When_using_custom_serialization_options : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_use_them()
+        {
+            var dataId = Guid.NewGuid();
+
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<EndpointThatHostsASaga>(
+                    b => b.When(session => session.SendLocal(new StartSaga { DataId = dataId })))
+                .Done(c => c.SagaDone)
+                .Run();
+
+            Assert.True(context.SagaDone);
+            Assert.That(context.CustomSerializedProperty, Is.EqualTo(dataId.ToString()));
+            Assert.That(context.StreamContent, Is.EqualTo(dataId.ToString()));
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool SagaDone { get; set; }
+            public string CustomSerializedProperty { get; set; }
+            public string StreamContent { get; set; }
+        }
+
+        public class EndpointThatHostsASaga : EndpointConfigurationBuilder
+        {
+            public EndpointThatHostsASaga() =>
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    var persistence = c.UsePersistence<DynamoDBPersistence>();
+                    var sagas = persistence.Sagas();
+                    sagas.MapOptions = new JsonSerializerOptions(sagas.MapOptions)
+                    {
+                        TypeInfoResolver = new SagaJsonContext(sagas.MapOptions),
+                        Converters = { new CustomConverter() }
+                    };
+                    sagas.ObjectOptions = new JsonSerializerOptions(sagas.ObjectOptions)
+                    {
+                        TypeInfoResolver = new SagaJsonContext(sagas.ObjectOptions),
+                        Converters = { new CustomConverter() }
+                    };
+                });
+
+            class CustomConverter : JsonConverter<MySagaData>
+            {
+                public override MySagaData Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+                {
+                    var sagaData = JsonSerializer.Deserialize<MySagaData>(ref reader, options.FromWithout<CustomConverter>());
+                    sagaData.ManagedByConverter = sagaData.Nested.SomeProperty;
+                    return sagaData;
+                }
+
+                public override void Write(Utf8JsonWriter writer, MySagaData value, JsonSerializerOptions options)
+                {
+                    value.ManagedByConverter = value.Nested.SomeProperty;
+                    JsonSerializer.Serialize(writer, value, options.FromWithout<CustomConverter>());
+                }
+            }
+
+            public class MySaga : Saga<MySagaData>,
+                IAmStartedByMessages<StartSaga>,
+                IHandleMessages<ContinueSaga>
+            {
+                public MySaga(Context context) => testContext = context;
+
+                public Task Handle(StartSaga message, IMessageHandlerContext context)
+                {
+                    Data.DataId = message.DataId;
+                    Data.Nested = new NestedObject { SomeProperty = message.DataId.ToString() };
+                    Data.SomeStream = new MemoryStream(Encoding.UTF8.GetBytes(message.DataId.ToString()));
+
+                    return context.SendLocal(new ContinueSaga { DataId = message.DataId });
+                }
+
+                public Task Handle(ContinueSaga message, IMessageHandlerContext context)
+                {
+                    MarkAsComplete();
+
+                    testContext.CustomSerializedProperty = Data.ManagedByConverter;
+                    testContext.StreamContent = Encoding.UTF8.GetString(Data.SomeStream.ToArray());
+                    testContext.SagaDone = true;
+                    return Task.CompletedTask;
+                }
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<MySagaData> mapper) =>
+                    mapper.MapSaga(m => m.DataId)
+                        .ToMessage<StartSaga>(m => m.DataId)
+                        .ToMessage<ContinueSaga>(m => m.DataId);
+
+                readonly Context testContext;
+            }
+        }
+
+        public class StartSaga : IMessage
+        {
+            public Guid DataId { get; set; }
+        }
+
+        public class ContinueSaga : IMessage
+        {
+            public Guid DataId { get; set; }
+        }
+    }
+
+    public class MySagaData : ContainSagaData
+    {
+        public virtual Guid DataId { get; set; }
+
+        public virtual NestedObject Nested { get; set; }
+
+        public string ManagedByConverter { get; set; }
+
+        // here to demonstrate the custom converters still work
+        public MemoryStream SomeStream { get; set; }
+    }
+
+    public class NestedObject
+    {
+        public string SomeProperty { get; set; }
+    }
+
+    [JsonSourceGenerationOptions(WriteIndented = true)]
+    [JsonSerializable(typeof(MySagaData))]
+    partial class SagaJsonContext : JsonSerializerContext
+    {
+    }
+}

--- a/src/NServiceBus.Persistence.DynamoDB.AcceptanceTests/When_using_custom_serialization_options.cs
+++ b/src/NServiceBus.Persistence.DynamoDB.AcceptanceTests/When_using_custom_serialization_options.cs
@@ -43,14 +43,9 @@ namespace NServiceBus.AcceptanceTests
                 {
                     var persistence = c.UsePersistence<DynamoDBPersistence>();
                     var sagas = persistence.Sagas();
-                    sagas.MapOptions = new JsonSerializerOptions(sagas.MapOptions)
+                    sagas.MapperOptions = new JsonSerializerOptions(sagas.MapperOptions)
                     {
-                        TypeInfoResolver = new SagaJsonContext(sagas.MapOptions),
-                        Converters = { new CustomConverter() }
-                    };
-                    sagas.ObjectOptions = new JsonSerializerOptions(sagas.ObjectOptions)
-                    {
-                        TypeInfoResolver = new SagaJsonContext(sagas.ObjectOptions),
+                        TypeInfoResolver = new SagaJsonContext(sagas.MapperOptions),
                         Converters = { new CustomConverter() }
                     };
                 });

--- a/src/NServiceBus.Persistence.DynamoDB/NServiceBus.Persistence.DynamoDB.csproj
+++ b/src/NServiceBus.Persistence.DynamoDB/NServiceBus.Persistence.DynamoDB.csproj
@@ -12,6 +12,7 @@
   <ItemGroup Label="Public dependencies">
     <PackageReference Include="NServiceBus" Version="[8.0.0, 9.0.0)" />
     <PackageReference Include="AWSSDK.DynamoDBv2" Version="[3.7.102.16, 4.0.0)" />
+    <PackageReference Include="System.Text.Json" Version="7.0.2" />
   </ItemGroup>
   
   <ItemGroup Label="Private dependencies">

--- a/src/NServiceBus.Persistence.DynamoDB/Saga/SagaPersistenceConfiguration.cs
+++ b/src/NServiceBus.Persistence.DynamoDB/Saga/SagaPersistenceConfiguration.cs
@@ -36,7 +36,6 @@
         /// </summary>
         public TimeSpan LeaseAcquisitionTimeout { get; set; } = TimeSpan.FromSeconds(10);
 
-        internal JsonSerializerOptions MapOptions { get; set; } = new(Mapper.MapDefaults);
-        internal JsonSerializerOptions ObjectOptions { get; set; } = new(Mapper.ObjectDefaults);
+        internal JsonSerializerOptions MapperOptions { get; set; } = new(DynamoDB.MapperOptions.Defaults);
     }
 }

--- a/src/NServiceBus.Persistence.DynamoDB/Saga/SagaPersistenceConfiguration.cs
+++ b/src/NServiceBus.Persistence.DynamoDB/Saga/SagaPersistenceConfiguration.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.Persistence.DynamoDB
 {
     using System;
+    using System.Text.Json;
 
     /// <summary>
     /// The saga persistence configuration options.
@@ -34,5 +35,8 @@
         /// How long the client should attempt to acquire a lock when using pessimistic locking before giving up.
         /// </summary>
         public TimeSpan LeaseAcquisitionTimeout { get; set; } = TimeSpan.FromSeconds(10);
+
+        internal JsonSerializerOptions MapOptions { get; set; } = Mapper.MapDefaults;
+        internal JsonSerializerOptions ObjectOptions { get; set; } = Mapper.ObjectDefaults;
     }
 }

--- a/src/NServiceBus.Persistence.DynamoDB/Saga/SagaPersistenceConfiguration.cs
+++ b/src/NServiceBus.Persistence.DynamoDB/Saga/SagaPersistenceConfiguration.cs
@@ -36,7 +36,7 @@
         /// </summary>
         public TimeSpan LeaseAcquisitionTimeout { get; set; } = TimeSpan.FromSeconds(10);
 
-        internal JsonSerializerOptions MapOptions { get; set; } = Mapper.MapDefaults;
-        internal JsonSerializerOptions ObjectOptions { get; set; } = Mapper.ObjectDefaults;
+        internal JsonSerializerOptions MapOptions { get; set; } = new(Mapper.MapDefaults);
+        internal JsonSerializerOptions ObjectOptions { get; set; } = new(Mapper.ObjectDefaults);
     }
 }

--- a/src/NServiceBus.Persistence.DynamoDB/Saga/SagaPersister.cs
+++ b/src/NServiceBus.Persistence.DynamoDB/Saga/SagaPersister.cs
@@ -185,7 +185,7 @@
 
         TSagaData? Deserialize<TSagaData>(Dictionary<string, AttributeValue> attributeValues, ContextBag context) where TSagaData : class, IContainSagaData
         {
-            var sagaData = Mapper.ToObject<TSagaData>(attributeValues);
+            var sagaData = Mapper.ToObject<TSagaData>(attributeValues, configuration.ObjectOptions);
             if (sagaData is null)
             {
                 return default;
@@ -260,7 +260,7 @@
 
         Dictionary<string, AttributeValue> Serialize(IContainSagaData sagaData, int version)
         {
-            var sagaDataMap = Mapper.ToMap(sagaData, sagaData.GetType());
+            var sagaDataMap = Mapper.ToMap(sagaData, sagaData.GetType(), configuration.MapOptions);
             sagaDataMap.Add(configuration.Table.PartitionKeyName, new AttributeValue { S = SagaPartitionKey(sagaData.Id) });
             sagaDataMap.Add(configuration.Table.SortKeyName, new AttributeValue { S = SagaSortKey(sagaData.Id) });
             sagaDataMap.Add(SagaMetadataAttributeName, new AttributeValue

--- a/src/NServiceBus.Persistence.DynamoDB/Saga/SagaPersister.cs
+++ b/src/NServiceBus.Persistence.DynamoDB/Saga/SagaPersister.cs
@@ -185,7 +185,7 @@
 
         TSagaData? Deserialize<TSagaData>(Dictionary<string, AttributeValue> attributeValues, ContextBag context) where TSagaData : class, IContainSagaData
         {
-            var sagaData = Mapper.ToObject<TSagaData>(attributeValues, configuration.ObjectOptions);
+            var sagaData = Mapper.ToObject<TSagaData>(attributeValues, configuration.MapperOptions);
             if (sagaData is null)
             {
                 return default;
@@ -260,7 +260,7 @@
 
         Dictionary<string, AttributeValue> Serialize(IContainSagaData sagaData, int version)
         {
-            var sagaDataMap = Mapper.ToMap(sagaData, sagaData.GetType(), configuration.MapOptions);
+            var sagaDataMap = Mapper.ToMap(sagaData, sagaData.GetType(), configuration.MapperOptions);
             sagaDataMap.Add(configuration.Table.PartitionKeyName, new AttributeValue { S = SagaPartitionKey(sagaData.Id) });
             sagaDataMap.Add(configuration.Table.SortKeyName, new AttributeValue { S = SagaSortKey(sagaData.Id) });
             sagaDataMap.Add(SagaMetadataAttributeName, new AttributeValue

--- a/src/NServiceBus.Persistence.DynamoDB/Serialization/HashSetOfNumberConverter.cs
+++ b/src/NServiceBus.Persistence.DynamoDB/Serialization/HashSetOfNumberConverter.cs
@@ -82,7 +82,6 @@ namespace NServiceBus.Persistence.DynamoDB
                     throw new JsonException();
                 }
 
-                // Deliberately not passing the options to use the default json serialization behavior
                 var set = JsonSerializer.Deserialize<TSet>(ref reader, optionsWithoutHashSetOfNumberConverter);
 
                 reader.Read();

--- a/src/NServiceBus.Persistence.DynamoDB/Serialization/HashSetOfNumberConverter.cs
+++ b/src/NServiceBus.Persistence.DynamoDB/Serialization/HashSetOfNumberConverter.cs
@@ -57,9 +57,42 @@ namespace NServiceBus.Persistence.DynamoDB
             public SetConverter(JsonSerializerOptions options)
                 => optionsWithoutHashSetOfNumberConverter = options.FromWithout<HashSetOfNumberConverter>();
 
-            public override TSet Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
-                throw new NotImplementedException(
-                $"The {GetType().FullName} should never be used on the read path since its sole purpose is to preserve information on the write path");
+            public override TSet? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            {
+                if (reader.TokenType != JsonTokenType.StartObject)
+                {
+                    throw new JsonException();
+                }
+
+                reader.Read();
+                if (reader.TokenType != JsonTokenType.PropertyName)
+                {
+                    throw new JsonException();
+                }
+
+                string? propertyName = reader.GetString();
+                if (propertyName != PropertyName)
+                {
+                    throw new JsonException();
+                }
+
+                reader.Read();
+                if (reader.TokenType != JsonTokenType.StartArray)
+                {
+                    throw new JsonException();
+                }
+
+                // Deliberately not passing the options to use the default json serialization behavior
+                var set = JsonSerializer.Deserialize<TSet>(ref reader, optionsWithoutHashSetOfNumberConverter);
+
+                reader.Read();
+
+                if (reader.TokenType != JsonTokenType.EndObject)
+                {
+                    throw new JsonException();
+                }
+                return set;
+            }
 
             public override void Write(Utf8JsonWriter writer, TSet value, JsonSerializerOptions options)
             {
@@ -90,12 +123,14 @@ namespace NServiceBus.Persistence.DynamoDB
 
         public static JsonNode ToNode(List<string> numbersAsStrings)
         {
+            var jsonObject = new JsonObject();
             var array = new JsonArray();
             foreach (var numberAsString in numbersAsStrings)
             {
                 array.Add(JsonNode.Parse(numberAsString));
             }
-            return array;
+            jsonObject.Add(PropertyName, array);
+            return jsonObject;
         }
     }
 }

--- a/src/NServiceBus.Persistence.DynamoDB/Serialization/HashSetStringConverter.cs
+++ b/src/NServiceBus.Persistence.DynamoDB/Serialization/HashSetStringConverter.cs
@@ -57,7 +57,6 @@ namespace NServiceBus.Persistence.DynamoDB
                     throw new JsonException();
                 }
 
-                // Deliberately not passing the options to use the default json serialization behavior
                 var set = JsonSerializer.Deserialize<TSet>(ref reader, optionsWithoutHashSetOfNumberConverter);
 
                 reader.Read();

--- a/src/NServiceBus.Persistence.DynamoDB/Serialization/Mapper.cs
+++ b/src/NServiceBus.Persistence.DynamoDB/Serialization/Mapper.cs
@@ -11,6 +11,9 @@ namespace NServiceBus.Persistence.DynamoDB
 
     static class Mapper
     {
+        /// <summary>
+        /// The defaults are never directly used to serialize and deserialize otherwise they become immutable
+        /// </summary>
         public static JsonSerializerOptions MapDefaults { get; } =
             new()
             {
@@ -23,6 +26,9 @@ namespace NServiceBus.Persistence.DynamoDB
                 }
             };
 
+        /// <summary>
+        /// The defaults are never directly used to serialize and deserialize otherwise they become immutable
+        /// </summary>
         public static JsonSerializerOptions ObjectDefaults { get; } =
             new()
             {
@@ -33,10 +39,14 @@ namespace NServiceBus.Persistence.DynamoDB
                 }
             };
 
+        static JsonSerializerOptions MapOptions { get; } = new(MapDefaults);
+
+        static JsonSerializerOptions ObjectOptions { get; } = new(ObjectDefaults);
+
         public static Dictionary<string, AttributeValue> ToMap<TValue>(TValue value, JsonSerializerOptions? options = null)
             where TValue : class
         {
-            using var jsonDocument = JsonSerializer.SerializeToDocument(value, options ?? MapDefaults);
+            using var jsonDocument = JsonSerializer.SerializeToDocument(value, options ?? MapOptions);
             if (jsonDocument.RootElement.ValueKind != JsonValueKind.Object)
             {
                 ThrowInvalidOperationExceptionForInvalidRoot(typeof(TValue));
@@ -69,7 +79,7 @@ namespace NServiceBus.Persistence.DynamoDB
 
         public static Dictionary<string, AttributeValue> ToMap(object value, Type type, JsonSerializerOptions? options = null)
         {
-            using var jsonDocument = JsonSerializer.SerializeToDocument(value, type, options ?? MapDefaults);
+            using var jsonDocument = JsonSerializer.SerializeToDocument(value, type, options ?? MapOptions);
             if (jsonDocument.RootElement.ValueKind != JsonValueKind.Object)
             {
                 ThrowInvalidOperationExceptionForInvalidRoot(type);
@@ -90,13 +100,13 @@ namespace NServiceBus.Persistence.DynamoDB
         public static TValue? ToObject<TValue>(Dictionary<string, AttributeValue> attributeValues, JsonSerializerOptions? options = null)
         {
             var jsonObject = ToNodeFromMap(attributeValues);
-            return jsonObject.Deserialize<TValue>(options ?? ObjectDefaults);
+            return jsonObject.Deserialize<TValue>(options ?? ObjectOptions);
         }
 
         public static object? ToObject(Dictionary<string, AttributeValue> attributeValues, Type returnType, JsonSerializerOptions? options = null)
         {
             var jsonObject = ToNodeFromMap(attributeValues);
-            return jsonObject.Deserialize(returnType, options ?? ObjectDefaults);
+            return jsonObject.Deserialize(returnType, options ?? ObjectOptions);
         }
 
         public static object? ToObject(Dictionary<string, AttributeValue> attributeValues, Type returnType, JsonSerializerContext context)

--- a/src/NServiceBus.Persistence.DynamoDB/Serialization/Mapper.cs
+++ b/src/NServiceBus.Persistence.DynamoDB/Serialization/Mapper.cs
@@ -11,42 +11,12 @@ namespace NServiceBus.Persistence.DynamoDB
 
     static class Mapper
     {
-        /// <summary>
-        /// The defaults are never directly used to serialize and deserialize otherwise they become immutable
-        /// </summary>
-        public static JsonSerializerOptions MapDefaults { get; } =
-            new()
-            {
-                Converters =
-                {
-                    new MemoryStreamConverter(),
-                    new HashSetMemoryStreamConverter(),
-                    new HashSetStringConverter(),
-                    new HashSetOfNumberConverter()
-                }
-            };
-
-        /// <summary>
-        /// The defaults are never directly used to serialize and deserialize otherwise they become immutable
-        /// </summary>
-        public static JsonSerializerOptions ObjectDefaults { get; } =
-            new()
-            {
-                Converters =
-                {
-                    new MemoryStreamConverter(),
-                    new HashSetMemoryStreamConverter()
-                }
-            };
-
-        static JsonSerializerOptions MapOptions { get; } = new(MapDefaults);
-
-        static JsonSerializerOptions ObjectOptions { get; } = new(ObjectDefaults);
+        static JsonSerializerOptions DefaultOptions { get; } = new(MapperOptions.Defaults);
 
         public static Dictionary<string, AttributeValue> ToMap<TValue>(TValue value, JsonSerializerOptions? options = null)
             where TValue : class
         {
-            using var jsonDocument = JsonSerializer.SerializeToDocument(value, options ?? MapOptions);
+            using var jsonDocument = JsonSerializer.SerializeToDocument(value, options ?? DefaultOptions);
             if (jsonDocument.RootElement.ValueKind != JsonValueKind.Object)
             {
                 ThrowInvalidOperationExceptionForInvalidRoot(typeof(TValue));
@@ -79,7 +49,7 @@ namespace NServiceBus.Persistence.DynamoDB
 
         public static Dictionary<string, AttributeValue> ToMap(object value, Type type, JsonSerializerOptions? options = null)
         {
-            using var jsonDocument = JsonSerializer.SerializeToDocument(value, type, options ?? MapOptions);
+            using var jsonDocument = JsonSerializer.SerializeToDocument(value, type, options ?? DefaultOptions);
             if (jsonDocument.RootElement.ValueKind != JsonValueKind.Object)
             {
                 ThrowInvalidOperationExceptionForInvalidRoot(type);
@@ -100,13 +70,13 @@ namespace NServiceBus.Persistence.DynamoDB
         public static TValue? ToObject<TValue>(Dictionary<string, AttributeValue> attributeValues, JsonSerializerOptions? options = null)
         {
             var jsonObject = ToNodeFromMap(attributeValues);
-            return jsonObject.Deserialize<TValue>(options ?? ObjectOptions);
+            return jsonObject.Deserialize<TValue>(options ?? DefaultOptions);
         }
 
         public static object? ToObject(Dictionary<string, AttributeValue> attributeValues, Type returnType, JsonSerializerOptions? options = null)
         {
             var jsonObject = ToNodeFromMap(attributeValues);
-            return jsonObject.Deserialize(returnType, options ?? ObjectOptions);
+            return jsonObject.Deserialize(returnType, options ?? DefaultOptions);
         }
 
         public static object? ToObject(Dictionary<string, AttributeValue> attributeValues, Type returnType, JsonSerializerContext context)

--- a/src/NServiceBus.Persistence.DynamoDB/Serialization/MapperOptions.cs
+++ b/src/NServiceBus.Persistence.DynamoDB/Serialization/MapperOptions.cs
@@ -1,0 +1,22 @@
+namespace NServiceBus.Persistence.DynamoDB
+{
+    using System.Text.Json;
+
+    static class MapperOptions
+    {
+        /// <summary>
+        /// The defaults are never directly used to serialize and deserialize otherwise they become immutable
+        /// </summary>
+        public static JsonSerializerOptions Defaults { get; } =
+            new()
+            {
+                Converters =
+                {
+                    new MemoryStreamConverter(),
+                    new HashSetMemoryStreamConverter(),
+                    new HashSetStringConverter(),
+                    new HashSetOfNumberConverter()
+                }
+            };
+    }
+}


### PR DESCRIPTION
This PR reintroduces symmetry in the serialization process so that one options instance can be used to configure the serializer from a public standpoint. It doesn't yet expose the options to public but adds verification that it works