### PR TITLE
Bump the minimum required version of the SDK to something current

### DIFF
--- a/src/NServiceBus.Persistence.DynamoDB/NServiceBus.Persistence.DynamoDB.csproj
+++ b/src/NServiceBus.Persistence.DynamoDB/NServiceBus.Persistence.DynamoDB.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup Label="Public dependencies">
     <PackageReference Include="NServiceBus" Version="[8.0.0, 9.0.0)" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="[3.7.3, 4.0.0)" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="[3.7.102.16, 4.0.0)" />
   </ItemGroup>
   
   <ItemGroup Label="Private dependencies">


### PR DESCRIPTION
This will also make sure we have a more recent AWSSDK.Core version