### PR TITLE
Saga key tweaks

### DIFF
--- a/src/NServiceBus.Persistence.DynamoDB.PersistenceTests/PersistenceTestsConfiguration.cs
+++ b/src/NServiceBus.Persistence.DynamoDB.PersistenceTests/PersistenceTestsConfiguration.cs
@@ -58,13 +58,14 @@
             var configuration = (PersistenceConfiguration)Variant.Values[0];
 
             SagaStorage = new SagaPersister(
+                Client,
                 new SagaPersistenceConfiguration
                 {
                     Table = SetupFixture.SagaTable,
                     UsePessimisticLocking = SupportsPessimisticConcurrency = configuration.UsePessimisticLocking,
                     LeaseAcquisitionTimeout = Variant.SessionTimeout ?? TimeSpan.FromSeconds(10)
                 },
-                Client);
+                "PersistenceTest");
 
             OutboxStorage = new OutboxPersister(
                 Client,

--- a/src/NServiceBus.Persistence.DynamoDB.Tests/ApprovalFiles/SagaSchemaVersionTest.Should_update_schema_version_on_schema_changes.approved.txt
+++ b/src/NServiceBus.Persistence.DynamoDB.Tests/ApprovalFiles/SagaSchemaVersionTest.Should_update_schema_version_on_schema_changes.approved.txt
@@ -71,7 +71,7 @@
     "N": null,
     "NS": [],
     "NULL": false,
-    "S": "SAGA#ffc8a2fd-0335-47c8-a29d-9eea6c8445d8",
+    "S": "SAGA#SCHEMAVERSIONTEST#ffc8a2fd-0335-47c8-a29d-9eea6c8445d8",
     "SS": []
   },
   "SK": {

--- a/src/NServiceBus.Persistence.DynamoDB.Tests/SagaSchemaVersionTest.cs
+++ b/src/NServiceBus.Persistence.DynamoDB.Tests/SagaSchemaVersionTest.cs
@@ -16,7 +16,7 @@
         [Test]
         public async Task Should_update_schema_version_on_schema_changes()
         {
-            var sagaPersister = new SagaPersister(new SagaPersistenceConfiguration(), new MockDynamoDBClient());
+            var sagaPersister = new SagaPersister(new MockDynamoDBClient(), new SagaPersistenceConfiguration(), "SchemaVersionTest");
 
             var sagaData = new TestSagaData()
             {

--- a/src/NServiceBus.Persistence.DynamoDB/Saga/SagaPersister.cs
+++ b/src/NServiceBus.Persistence.DynamoDB/Saga/SagaPersister.cs
@@ -47,7 +47,7 @@
                     Key = new Dictionary<string, AttributeValue>
                     {
                         { configuration.Table.PartitionKeyName, new AttributeValue { S = SagaPartitionKey(sagaId) } },
-                        { configuration.Table.SortKeyName, new AttributeValue { S = $"SAGA#{sagaId}" } }, //Sort key
+                        { configuration.Table.SortKeyName, new AttributeValue { S = SagaSortKey(sagaId) } }
                     },
                     TableName = configuration.Table.TableName
                 };
@@ -76,7 +76,7 @@
                         Key = new Dictionary<string, AttributeValue>
                         {
                             { configuration.Table.PartitionKeyName, new AttributeValue { S = SagaPartitionKey(sagaId) } },
-                            { configuration.Table.SortKeyName, new AttributeValue { S = $"SAGA#{sagaId}" } }
+                            { configuration.Table.SortKeyName, new AttributeValue { S = SagaSortKey(sagaId) } }
                         },
                         UpdateExpression = "SET #lease = :lease_timeout",
                         ConditionExpression = "attribute_not_exists(#lease) OR #lease < :now",
@@ -111,7 +111,7 @@
                                 Key = new Dictionary<string, AttributeValue>
                                 {
                                     { configuration.Table.PartitionKeyName, new AttributeValue { S = SagaPartitionKey(sagaId) } },
-                                    { configuration.Table.SortKeyName, new AttributeValue { S = $"SAGA#{sagaId}" } }
+                                    { configuration.Table.SortKeyName, new AttributeValue { S = SagaSortKey(sagaId) } }
                                 },
                                 UpdateExpression = "SET #lease = :released_lease",
                                 ConditionExpression = "#lease = :current_lease AND #metadata.#version = :current_version", // only if the lock is still the same that we acquired.
@@ -145,7 +145,7 @@
                                 Key = new Dictionary<string, AttributeValue>
                                 {
                                     { configuration.Table.PartitionKeyName, new AttributeValue { S = SagaPartitionKey(sagaId) } },
-                                    { configuration.Table.SortKeyName, new AttributeValue { S = $"SAGA#{sagaId}" } }
+                                    { configuration.Table.SortKeyName, new AttributeValue { S = SagaSortKey(sagaId) } }
                                 },
                                 ConditionExpression = "#lease = :current_lease AND attribute_not_exists(#metadata)", // only if the lock is still the same that we acquired.
                                 ExpressionAttributeNames = new Dictionary<string, string>
@@ -262,7 +262,7 @@
         {
             var sagaDataMap = Mapper.ToMap(sagaData, sagaData.GetType());
             sagaDataMap.Add(configuration.Table.PartitionKeyName, new AttributeValue { S = SagaPartitionKey(sagaData.Id) });
-            sagaDataMap.Add(configuration.Table.SortKeyName, new AttributeValue { S = $"SAGA#{sagaData.Id}" });  //Sort key
+            sagaDataMap.Add(configuration.Table.SortKeyName, new AttributeValue { S = SagaSortKey(sagaData.Id) });
             sagaDataMap.Add(SagaMetadataAttributeName, new AttributeValue
             {
                 M = new Dictionary<string, AttributeValue>()
@@ -288,7 +288,7 @@
                     Key = new Dictionary<string, AttributeValue>
                     {
                         {configuration.Table.PartitionKeyName, new AttributeValue {S = SagaPartitionKey(sagaData.Id)}},
-                        {configuration.Table.SortKeyName, new AttributeValue {S = $"SAGA#{sagaData.Id}"}}, //Sort key
+                        {configuration.Table.SortKeyName, new AttributeValue {S = SagaSortKey(sagaData.Id)}}
                     },
                     ConditionExpression = "#metadata.#version = :current_version", // fail if modified in the meantime
                     ExpressionAttributeNames = new Dictionary<string, string>
@@ -315,5 +315,7 @@
         }
 
         string SagaPartitionKey(Guid sagaId) => $"SAGA#{endpointIdentifier}#{sagaId}";
+
+        string SagaSortKey(Guid sagaId) => $"SAGA#{sagaId}";
     }
 }

--- a/src/NServiceBus.Persistence.DynamoDB/Saga/SagaPersister.cs
+++ b/src/NServiceBus.Persistence.DynamoDB/Saga/SagaPersister.cs
@@ -46,7 +46,7 @@
                     ConsistentRead = true,
                     Key = new Dictionary<string, AttributeValue>
                     {
-                        { configuration.Table.PartitionKeyName, new AttributeValue { S = CreateOutboxPartitionKey(sagaId) } },
+                        { configuration.Table.PartitionKeyName, new AttributeValue { S = SagaPartitionKey(sagaId) } },
                         { configuration.Table.SortKeyName, new AttributeValue { S = $"SAGA#{sagaId}" } }, //Sort key
                     },
                     TableName = configuration.Table.TableName
@@ -75,7 +75,7 @@
                     {
                         Key = new Dictionary<string, AttributeValue>
                         {
-                            { configuration.Table.PartitionKeyName, new AttributeValue { S = CreateOutboxPartitionKey(sagaId) } },
+                            { configuration.Table.PartitionKeyName, new AttributeValue { S = SagaPartitionKey(sagaId) } },
                             { configuration.Table.SortKeyName, new AttributeValue { S = $"SAGA#{sagaId}" } }
                         },
                         UpdateExpression = "SET #lease = :lease_timeout",
@@ -110,7 +110,7 @@
                             {
                                 Key = new Dictionary<string, AttributeValue>
                                 {
-                                    { configuration.Table.PartitionKeyName, new AttributeValue { S = CreateOutboxPartitionKey(sagaId) } },
+                                    { configuration.Table.PartitionKeyName, new AttributeValue { S = SagaPartitionKey(sagaId) } },
                                     { configuration.Table.SortKeyName, new AttributeValue { S = $"SAGA#{sagaId}" } }
                                 },
                                 UpdateExpression = "SET #lease = :released_lease",
@@ -144,7 +144,7 @@
                             {
                                 Key = new Dictionary<string, AttributeValue>
                                 {
-                                    { configuration.Table.PartitionKeyName, new AttributeValue { S = CreateOutboxPartitionKey(sagaId) } },
+                                    { configuration.Table.PartitionKeyName, new AttributeValue { S = SagaPartitionKey(sagaId) } },
                                     { configuration.Table.SortKeyName, new AttributeValue { S = $"SAGA#{sagaId}" } }
                                 },
                                 ConditionExpression = "#lease = :current_lease AND attribute_not_exists(#metadata)", // only if the lock is still the same that we acquired.
@@ -261,7 +261,7 @@
         Dictionary<string, AttributeValue> Serialize(IContainSagaData sagaData, int version)
         {
             var sagaDataMap = Mapper.ToMap(sagaData, sagaData.GetType());
-            sagaDataMap.Add(configuration.Table.PartitionKeyName, new AttributeValue { S = CreateOutboxPartitionKey(sagaData.Id) });
+            sagaDataMap.Add(configuration.Table.PartitionKeyName, new AttributeValue { S = SagaPartitionKey(sagaData.Id) });
             sagaDataMap.Add(configuration.Table.SortKeyName, new AttributeValue { S = $"SAGA#{sagaData.Id}" });  //Sort key
             sagaDataMap.Add(SagaMetadataAttributeName, new AttributeValue
             {
@@ -287,7 +287,7 @@
                 {
                     Key = new Dictionary<string, AttributeValue>
                     {
-                        {configuration.Table.PartitionKeyName, new AttributeValue {S = CreateOutboxPartitionKey(sagaData.Id)}},
+                        {configuration.Table.PartitionKeyName, new AttributeValue {S = SagaPartitionKey(sagaData.Id)}},
                         {configuration.Table.SortKeyName, new AttributeValue {S = $"SAGA#{sagaData.Id}"}}, //Sort key
                     },
                     ConditionExpression = "#metadata.#version = :current_version", // fail if modified in the meantime
@@ -314,6 +314,6 @@
             return Get<TSagaData>(sagaId, session, context, cancellationToken);
         }
 
-        string CreateOutboxPartitionKey(Guid sagaId) => $"SAGA#{endpointIdentifier}#{sagaId}";
+        string SagaPartitionKey(Guid sagaId) => $"SAGA#{endpointIdentifier}#{sagaId}";
     }
 }

--- a/src/NServiceBus.Persistence.DynamoDB/Saga/SagaStorage.cs
+++ b/src/NServiceBus.Persistence.DynamoDB/Saga/SagaStorage.cs
@@ -24,7 +24,10 @@
             // By default, use the endpoint name for the saga table name to store all sagas
             var sagaConfiguration = context.Settings.Get<SagaPersistenceConfiguration>();
 
-            context.Services.AddSingleton<ISagaPersister>(provider => new SagaPersister(sagaConfiguration, provider.GetRequiredService<IDynamoDBClientProvider>().Client));
+            context.Services.AddSingleton<ISagaPersister>(provider => new SagaPersister(
+                provider.GetRequiredService<IDynamoDBClientProvider>().Client,
+                sagaConfiguration,
+                context.Settings.EndpointName()));
         }
     }
 }


### PR DESCRIPTION
Adding the endpoint identifier to the saga partition key without changing the saga ID generation logic. This makes it safer to avoid any sort of cross-endpoint leaks in case saga types are very similar/shared for some reason. Additionally, this aligns the partition key with the outbox records which also contain an endpoint identifier.