### PR TITLE
Throw if session is used after disposal

### DIFF
--- a/src/NServiceBus.Persistence.DynamoDB.Tests/StorageSessionTests.cs
+++ b/src/NServiceBus.Persistence.DynamoDB.Tests/StorageSessionTests.cs
@@ -1,0 +1,22 @@
+﻿namespace NServiceBus.Persistence.DynamoDB.Tests
+{
+    using System;
+    using Amazon.DynamoDBv2.Model;
+    using Extensibility;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class StorageSessionTests
+    {
+        [Test]
+        public void Should_throw_exception_when_adding_operations_after_dispose()
+        {
+            var session = new StorageSession(new MockDynamoDBClient(), new ContextBag());
+
+            session.Dispose();
+
+            Assert.Throws<ObjectDisposedException>(() => session.Add(new TransactWriteItem()));
+            Assert.Throws<ObjectDisposedException>(() => session.AddRange(new[] { new TransactWriteItem(), new TransactWriteItem() }));
+        }
+    }
+}

--- a/src/NServiceBus.Persistence.DynamoDB.Tests/StorageSessionTests.cs
+++ b/src/NServiceBus.Persistence.DynamoDB.Tests/StorageSessionTests.cs
@@ -1,6 +1,8 @@
 ﻿namespace NServiceBus.Persistence.DynamoDB.Tests
 {
     using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
     using Amazon.DynamoDBv2.Model;
     using Extensibility;
     using NUnit.Framework;
@@ -9,7 +11,48 @@
     public class StorageSessionTests
     {
         [Test]
-        public void Should_throw_exception_when_adding_operations_after_dispose()
+        public void Dispose_should_call_cleanup_actions()
+        {
+            var calledCleanupActions = new List<Guid>();
+            Task CleanupAction(Guid guid)
+            {
+                calledCleanupActions.Add(guid);
+                return Task.CompletedTask;
+            }
+
+            var action1 = Guid.NewGuid();
+            var action2 = Guid.NewGuid();
+
+            var session = new StorageSession(new MockDynamoDBClient(), new ContextBag());
+            session.CleanupActions[action1] = (_, _) => CleanupAction(action1);
+            session.CleanupActions[action2] = (_, _) => CleanupAction(action2);
+
+            // the cleanup happens async, but because we're never actually move away from sync code paths, we can immediately assert after calling dispose
+            session.Dispose();
+
+            Assert.That(calledCleanupActions, Has.Count.EqualTo(2));
+            Assert.That(calledCleanupActions, Contains.Item(action1).And.Contains(action2));
+        }
+
+        [Test]
+        public void Dispose_should_call_cleanup_actions_only_once()
+        {
+            int counter = 0;
+            var session = new StorageSession(new MockDynamoDBClient(), new ContextBag());
+            session.CleanupActions[Guid.NewGuid()] = (_, _) =>
+            {
+                counter++;
+                return Task.CompletedTask;
+            };
+
+            session.Dispose();
+            session.Dispose();
+
+            Assert.AreEqual(1, counter);
+        }
+
+        [Test]
+        public void Add_should_throw_exception_when_adding_operations_after_disposal()
         {
             var session = new StorageSession(new MockDynamoDBClient(), new ContextBag());
 

--- a/src/NServiceBus.Persistence.DynamoDB/SynchronizedStorage/DynamoDBSynchronizedStorageSession.cs
+++ b/src/NServiceBus.Persistence.DynamoDB/SynchronizedStorage/DynamoDBSynchronizedStorageSession.cs
@@ -38,8 +38,7 @@
         }
 
         public ValueTask<bool> TryOpen(TransportTransaction transportTransaction, ContextBag context,
-            CancellationToken cancellationToken = default) =>
-            new ValueTask<bool>(false);
+            CancellationToken cancellationToken = default) => new(false);
 
         public Task Open(ContextBag contextBag, CancellationToken cancellationToken = default)
         {

--- a/src/NServiceBus.Persistence.DynamoDB/SynchronizedStorage/StorageSession.cs
+++ b/src/NServiceBus.Persistence.DynamoDB/SynchronizedStorage/StorageSession.cs
@@ -27,12 +27,14 @@
 
         public void Add(TransactWriteItem writeItem)
         {
+            ThrowIfDisposed();
             batch.Add(writeItem);
             CheckCapacity();
         }
 
         public void AddRange(IEnumerable<TransactWriteItem> writeItems)
         {
+            ThrowIfDisposed();
             batch.AddRange(writeItems);
             CheckCapacity();
         }
@@ -57,12 +59,10 @@
             var transactItemsRequest = new TransactWriteItemsRequest { TransactItems = batch };
             var response = await dynamoDbClient.TransactWriteItemsAsync(transactItemsRequest, cancellationToken).ConfigureAwait(false);
             batch.Clear();
-            // TODO: Check response
-            // TODO: Add retries
-            // TODO: Do we need to verify streams are disposed or is the SDK doing this?
+
             if (response.HttpStatusCode != HttpStatusCode.OK)
             {
-                throw new InvalidOperationException("Unable to complete transaction. Retrying");
+                throw new InvalidOperationException($"Unable to complete transaction (status code: {response.HttpStatusCode}.");
             }
 
             // The transaction operations already released any lock, don't clean them up explicitly
@@ -74,7 +74,7 @@
 
         public void Dispose()
         {
-
+            disposed = true;
             // release lock as fire & forget
             _ = ReleaseLocksAsync();
 
@@ -98,9 +98,19 @@
             }
         }
 
+        void ThrowIfDisposed()
+        {
+            if (disposed)
+            {
+                throw new ObjectDisposedException(
+                    $"The storage session has already been disposed. Make sure to retrieve the current storage session from the `{nameof(IMessageHandlerContext)}.{nameof(IMessageHandlerContext.SynchronizedStorageSession)}` or by injecting `{nameof(ICompletableSynchronizedStorageSession)}`.");
+            }
+        }
+
         public ContextBag CurrentContextBag { get; set; }
 
         List<TransactWriteItem> batch = new List<TransactWriteItem>();
         readonly IAmazonDynamoDB dynamoDbClient;
+        bool disposed;
     }
 }

--- a/src/NServiceBus.Persistence.DynamoDB/SynchronizedStorage/StorageSession.cs
+++ b/src/NServiceBus.Persistence.DynamoDB/SynchronizedStorage/StorageSession.cs
@@ -74,9 +74,14 @@
 
         public void Dispose()
         {
-            disposed = true;
+            if (disposed)
+            {
+                return;
+            }
+
             // release lock as fire & forget
             _ = ReleaseLocksAsync();
+            disposed = true;
 
             async Task ReleaseLocksAsync()
             {
@@ -95,8 +100,6 @@
                         Logger.Warn("Failed to cleanup saga locks", e);
                     }
                 }
-
-                CleanupActions.Clear();
             }
         }
 

--- a/src/NServiceBus.Persistence.DynamoDB/SynchronizedStorage/StorageSession.cs
+++ b/src/NServiceBus.Persistence.DynamoDB/SynchronizedStorage/StorageSession.cs
@@ -95,6 +95,8 @@
                         Logger.Warn("Failed to cleanup saga locks", e);
                     }
                 }
+
+                CleanupActions.Clear();
             }
         }
 


### PR DESCRIPTION
To help detect references to storage sessions that should no longer be used (e.g. due to incorrect lifetime scopes in DI or static references etc.)