### PR TITLE
Add explicit package dependency for TxSession ATT

### DIFF
--- a/src/NServiceBus.Persistence.DynamoDB.TransactionalSession.AcceptanceTests/NServiceBus.Persistence.DynamoDB.TransactionalSession.AcceptanceTests.csproj
+++ b/src/NServiceBus.Persistence.DynamoDB.TransactionalSession.AcceptanceTests/NServiceBus.Persistence.DynamoDB.TransactionalSession.AcceptanceTests.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.102.19" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="NServiceBus.AcceptanceTesting" Version="8.0.3" />
+    <PackageReference Include="NServiceBus.TransactionalSession" Version="2.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
     <PackageReference Include="Nunit" Version="3.13.3" />
   </ItemGroup>


### PR DESCRIPTION
I noticed on the last dependabot PR that the ATT don't contain a reference to the package, which they should so that the tests always run against the latest verison.