### PR TITLE
AWS SDK Client Cache hack removal

### DIFF
--- a/src/NServiceBus.Persistence.DynamoDB.AcceptanceTests/NServiceBus.Persistence.DynamoDB.AcceptanceTests.csproj
+++ b/src/NServiceBus.Persistence.DynamoDB.AcceptanceTests/NServiceBus.Persistence.DynamoDB.AcceptanceTests.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.102.30" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.102.31" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="NServiceBus.Testing" Version="8.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />

--- a/src/NServiceBus.Persistence.DynamoDB.PersistenceTests/NServiceBus.Persistence.DynamoDB.PersistenceTests.csproj
+++ b/src/NServiceBus.Persistence.DynamoDB.PersistenceTests/NServiceBus.Persistence.DynamoDB.PersistenceTests.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.102.30" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.102.31" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="NServiceBus" Version="8.0.3" />
     <PackageReference Include="NServiceBus.Testing" Version="8.0.1" />

--- a/src/NServiceBus.Persistence.DynamoDB.PessimisticLock.AcceptanceTests/NServiceBus.Persistence.DynamoDB.PessimisticLock.AcceptanceTests.csproj
+++ b/src/NServiceBus.Persistence.DynamoDB.PessimisticLock.AcceptanceTests/NServiceBus.Persistence.DynamoDB.PessimisticLock.AcceptanceTests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.102.30" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.102.31" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="NServiceBus.Testing" Version="8.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />

--- a/src/NServiceBus.Persistence.DynamoDB.Tests/ClientFactory.cs
+++ b/src/NServiceBus.Persistence.DynamoDB.Tests/ClientFactory.cs
@@ -9,7 +9,8 @@ namespace NServiceBus.Persistence.DynamoDB.Tests
         public static IAmazonDynamoDB CreateDynamoDBClient(Action<AmazonDynamoDBConfig> configure = default)
         {
             AWSCredentials credentials = new EnvironmentVariablesAWSCredentials();
-            var config = Create(configure);
+            var config = new AmazonDynamoDBConfig();
+            configure?.Invoke(config);
 
             if (string.IsNullOrEmpty(
                     Environment.GetEnvironmentVariable(
@@ -21,24 +22,6 @@ namespace NServiceBus.Persistence.DynamoDB.Tests
             }
 
             return new AmazonDynamoDBClient(credentials, config);
-        }
-
-        // Can be removed once https://github.com/aws/aws-sdk-net/issues/1929 is addressed by the team
-        // setting the cache size to 1 will significantly improve the throughput on non-windows OSS while
-        // windows had already 1 as the default.
-        // There might be other occurrences of setting this setting explicitly in the code base. Make sure to remove them
-        // consistently once the issue is addressed.
-        // The method is deliberately generic because this config should be set on any SDK client.
-        static TConfig Create<TConfig>(Action<TConfig> configure = default)
-            where TConfig : ClientConfig, new()
-        {
-#if NET
-            var config = new TConfig { HttpClientCacheSize = 1 };
-#else
-            var config = new TConfig();
-#endif
-            configure?.Invoke(config);
-            return config;
         }
     }
 }

--- a/src/NServiceBus.Persistence.DynamoDB.Tests/NServiceBus.Persistence.DynamoDB.Tests.csproj
+++ b/src/NServiceBus.Persistence.DynamoDB.Tests/NServiceBus.Persistence.DynamoDB.Tests.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.102.30" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.102.31" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="NServiceBus" Version="8.0.3" />
     <PackageReference Include="NServiceBus.Testing" Version="8.0.1" />

--- a/src/NServiceBus.Persistence.DynamoDB.TransactionalSession.AcceptanceTests/NServiceBus.Persistence.DynamoDB.TransactionalSession.AcceptanceTests.csproj
+++ b/src/NServiceBus.Persistence.DynamoDB.TransactionalSession.AcceptanceTests/NServiceBus.Persistence.DynamoDB.TransactionalSession.AcceptanceTests.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.102.30" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.102.31" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="NServiceBus.AcceptanceTesting" Version="8.0.3" />
     <PackageReference Include="NServiceBus.TransactionalSession" Version="2.0.1" />

--- a/src/NServiceBus.Persistence.DynamoDB.TransactionalSession/NServiceBus.Persistence.DynamoDB.TransactionalSession.csproj
+++ b/src/NServiceBus.Persistence.DynamoDB.TransactionalSession/NServiceBus.Persistence.DynamoDB.TransactionalSession.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup Label="Public dependencies">
     <PackageReference Include="Particular.Packaging" Version="2.3.0" PrivateAssets="All" />
-    <PackageReference Include="NServiceBus.TransactionalSession" Version="[2.0.0, 3.0.0)" />
+    <PackageReference Include="NServiceBus.TransactionalSession" Version="[2.0.1, 3.0.0)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.Persistence.DynamoDB/NServiceBus.Persistence.DynamoDB.csproj
+++ b/src/NServiceBus.Persistence.DynamoDB/NServiceBus.Persistence.DynamoDB.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup Label="Public dependencies">
     <PackageReference Include="NServiceBus" Version="[8.0.0, 9.0.0)" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="[3.7.102.16, 4.0.0)" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="[3.7.102.31, 4.0.0)" />
     <PackageReference Include="System.Text.Json" Version="7.0.2" />
   </ItemGroup>
   


### PR DESCRIPTION
According to https://github.com/aws/aws-sdk-net/pull/2549#issuecomment-1500486145 the versions that target Version [3.7.106.15](https://www.nuget.org/packages/AWSSDK.Core/3.7.106.15) of Core should have the fix now applied and we can remove the hack.

Since any version or higher that targets that core version works I decided to bump to latest.