### PR TITLE
Small converter alignment

### DIFF
--- a/src/NServiceBus.Persistence.DynamoDB/Serialization/IAttributeConverter.cs
+++ b/src/NServiceBus.Persistence.DynamoDB/Serialization/IAttributeConverter.cs
@@ -1,0 +1,14 @@
+namespace NServiceBus.Persistence.DynamoDB
+{
+    using System.Diagnostics.CodeAnalysis;
+    using System.Text.Json;
+    using System.Text.Json.Nodes;
+    using Amazon.DynamoDBv2.Model;
+
+    interface IAttributeConverter
+    {
+        bool TryExtract(JsonElement element, [NotNullWhen(true)] out AttributeValue? attributeValue);
+
+        JsonNode ToNode(AttributeValue attributeValue);
+    }
+}


### PR DESCRIPTION
Last small refactoring that makes sure both paths pass on options and use the options to get converters

Makes sure both mapper paths use the options to not create a misalignment on both paths that would potentially confuse us later. 