### PR TITLE
Upper case attribute names

### DIFF
--- a/src/NServiceBus.Persistence.DynamoDB.AcceptanceTests/When_sending_many_messages_with_outbox_enabled.cs
+++ b/src/NServiceBus.Persistence.DynamoDB.AcceptanceTests/When_sending_many_messages_with_outbox_enabled.cs
@@ -10,6 +10,7 @@ using AcceptanceTesting.Customization;
 using Amazon.DynamoDBv2.Model;
 using EndpointTemplates;
 using NUnit.Framework;
+using static Persistence.DynamoDB.OutboxAttributeNames;
 
 public class When_sending_many_messages_with_outbox_enabled : NServiceBusAcceptanceTest
 {
@@ -52,8 +53,8 @@ public class When_sending_many_messages_with_outbox_enabled : NServiceBusAccepta
 
         var metadataAttributeMap = response.Items.Single();
         // Should be marked as dispatched
-        Assert.That(metadataAttributeMap["Dispatched"].BOOL, Is.True);
-        Assert.That(metadataAttributeMap["DispatchedAt"].S, Is.Not.Null);
+        Assert.That(metadataAttributeMap[Dispatched].BOOL, Is.True);
+        Assert.That(metadataAttributeMap[DispatchedAt].S, Is.Not.Null);
     }
 
     class Context : ScenarioContext

--- a/src/NServiceBus.Persistence.DynamoDB.Tests/ApprovalFiles/OutboxSchemaVersionTest.Should_update_schema_version_on_schema_changes.approved.txt
+++ b/src/NServiceBus.Persistence.DynamoDB.Tests/ApprovalFiles/OutboxSchemaVersionTest.Should_update_schema_version_on_schema_changes.approved.txt
@@ -39,7 +39,7 @@
           "S": "OUTBOX#METADATA#FFC8A2FD-0335-47C8-A29D-9EEA6C8445D8",
           "SS": []
         },
-        "TransportOperationsCount": {
+        "OPERATIONS_COUNT": {
           "B": null,
           "BOOL": false,
           "IsBOOLSet": false,
@@ -54,7 +54,7 @@
           "S": null,
           "SS": []
         },
-        "Dispatched": {
+        "DISPATCHED": {
           "B": null,
           "BOOL": false,
           "IsBOOLSet": true,
@@ -69,7 +69,7 @@
           "S": null,
           "SS": []
         },
-        "DispatchedAt": {
+        "DISPATCHED_AT": {
           "B": null,
           "BOOL": false,
           "IsBOOLSet": false,
@@ -84,7 +84,7 @@
           "S": null,
           "SS": []
         },
-        "SchemaVersion": {
+        "SCHEMA_VERSION": {
           "B": null,
           "BOOL": false,
           "IsBOOLSet": false,
@@ -99,7 +99,7 @@
           "S": "1.0",
           "SS": []
         },
-        "ExpiresAt": {
+        "EXPIRES_AT": {
           "B": null,
           "BOOL": false,
           "IsBOOLSet": false,

--- a/src/NServiceBus.Persistence.DynamoDB/Outbox/OutboxAttributeNames.cs
+++ b/src/NServiceBus.Persistence.DynamoDB/Outbox/OutboxAttributeNames.cs
@@ -1,0 +1,13 @@
+namespace NServiceBus.Persistence.DynamoDB;
+
+static class OutboxAttributeNames
+{
+    public const string Dispatched = "DISPATCHED";
+    public const string DispatchedAt = "DISPATCHED_AT";
+    public const string OperationsCount = "OPERATIONS_COUNT";
+    public const string MessageId = "MESSAGE_ID";
+    public const string Properties = "PROPERTIES";
+    public const string Headers = "HEADERS";
+    public const string Body = "BODY";
+    public const string SchemaVersion = "SCHEMA_VERSION";
+}

--- a/src/NServiceBus.Persistence.DynamoDB/TableConfiguration.cs
+++ b/src/NServiceBus.Persistence.DynamoDB/TableConfiguration.cs
@@ -37,9 +37,9 @@ public record TableConfiguration
     /// The attribute name for the Time to Live setting.
     /// </summary>
     /// <remarks>
-    /// The default value is <value>"ExpiresAt"</value>
+    /// The default value is <value>"EXPIRES_AT"</value>
     /// </remarks>
-    public string? TimeToLiveAttributeName { get; set; } = "ExpiresAt";
+    public string? TimeToLiveAttributeName { get; set; } = "EXPIRES_AT";
 
     /// <summary>
     /// The billing mode for this table


### PR DESCRIPTION
As discussed we standardize on upper casing as suggested by the best practices which makes sure the entries are sorted properly.

https://dynobase.dev/dynamodb-faq/is-it-possible-to-make-a-dynamodb-table-case-insensitive/

![image](https://user-images.githubusercontent.com/174258/234834004-9bde9480-0f6e-401d-8736-9ef514d2f7e2.png)

> To avoid odd behavior around this, you should standardize your sort keys in all uppercase or all lowercase values