### PR TITLE
Use camel casing and make endpoint identifier case sensitive

### DIFF
--- a/src/NServiceBus.Persistence.DynamoDB.AcceptanceTests/When_sending_many_messages_with_outbox_enabled.cs
+++ b/src/NServiceBus.Persistence.DynamoDB.AcceptanceTests/When_sending_many_messages_with_outbox_enabled.cs
@@ -32,8 +32,7 @@ public class When_sending_many_messages_with_outbox_enabled : NServiceBusAccepta
 
         Assert.AreEqual(99, context.MessagesReceived);
 
-        var endpointName = Conventions.EndpointNamingConvention(typeof(EndpointSendingManyMessages))
-            .ToUpperInvariant();
+        var endpointName = Conventions.EndpointNamingConvention(typeof(EndpointSendingManyMessages));
         var queryRequest = new QueryRequest
         {
             ConsistentRead = true,

--- a/src/NServiceBus.Persistence.DynamoDB.Tests/ApprovalFiles/OutboxSchemaVersionTests.Should_update_schema_version_on_schema_changes.approved.txt
+++ b/src/NServiceBus.Persistence.DynamoDB.Tests/ApprovalFiles/OutboxSchemaVersionTests.Should_update_schema_version_on_schema_changes.approved.txt
@@ -21,7 +21,7 @@
           "N": null,
           "NS": [],
           "NULL": false,
-          "S": "OUTBOX#SCHEMAVERSIONTEST#FFC8A2FD-0335-47C8-A29D-9EEA6C8445D8",
+          "S": "OUTBOX#SchemaVersionTest#FFC8A2FD-0335-47C8-A29D-9EEA6C8445D8",
           "SS": []
         },
         "SK": {
@@ -39,7 +39,7 @@
           "S": "OUTBOX#METADATA#FFC8A2FD-0335-47C8-A29D-9EEA6C8445D8",
           "SS": []
         },
-        "OPERATIONS_COUNT": {
+        "OperationsCount": {
           "B": null,
           "BOOL": false,
           "IsBOOLSet": false,
@@ -54,7 +54,7 @@
           "S": null,
           "SS": []
         },
-        "DISPATCHED": {
+        "Dispatched": {
           "B": null,
           "BOOL": false,
           "IsBOOLSet": true,
@@ -69,7 +69,7 @@
           "S": null,
           "SS": []
         },
-        "DISPATCHED_AT": {
+        "DispatchedAt": {
           "B": null,
           "BOOL": false,
           "IsBOOLSet": false,
@@ -84,7 +84,7 @@
           "S": null,
           "SS": []
         },
-        "SCHEMA_VERSION": {
+        "SchemaVersion": {
           "B": null,
           "BOOL": false,
           "IsBOOLSet": false,
@@ -99,7 +99,7 @@
           "S": "1.0",
           "SS": []
         },
-        "EXPIRES_AT": {
+        "ExpiresAt": {
           "B": null,
           "BOOL": false,
           "IsBOOLSet": false,

--- a/src/NServiceBus.Persistence.DynamoDB.Tests/ApprovalFiles/SagaSchemaVersionTests.Should_update_schema_version_on_schema_changes.approved.txt
+++ b/src/NServiceBus.Persistence.DynamoDB.Tests/ApprovalFiles/SagaSchemaVersionTests.Should_update_schema_version_on_schema_changes.approved.txt
@@ -71,7 +71,7 @@
     "N": null,
     "NS": [],
     "NULL": false,
-    "S": "SAGA#SCHEMAVERSIONTEST#ffc8a2fd-0335-47c8-a29d-9eea6c8445d8",
+    "S": "SAGA#SchemaVersionTest#ffc8a2fd-0335-47c8-a29d-9eea6c8445d8",
     "SS": []
   },
   "SK": {
@@ -89,7 +89,7 @@
     "S": "SAGA#ffc8a2fd-0335-47c8-a29d-9eea6c8445d8",
     "SS": []
   },
-  "NSERVICEBUS_METADATA": {
+  "NServiceBus_Metadata": {
     "B": null,
     "BOOL": false,
     "IsBOOLSet": false,
@@ -97,7 +97,7 @@
     "L": [],
     "IsLSet": false,
     "M": {
-      "VERSION": {
+      "Version": {
         "B": null,
         "BOOL": false,
         "IsBOOLSet": false,
@@ -112,7 +112,7 @@
         "S": null,
         "SS": []
       },
-      "TYPE": {
+      "Type": {
         "B": null,
         "BOOL": false,
         "IsBOOLSet": false,
@@ -124,10 +124,10 @@
         "N": null,
         "NS": [],
         "NULL": false,
-        "S": "NServiceBus.Persistence.DynamoDB.Tests.SagaSchemaVersionTest\u002BTestSagaData",
+        "S": "NServiceBus.Persistence.DynamoDB.Tests.SagaSchemaVersionTests\u002BTestSagaData",
         "SS": []
       },
-      "SCHEMA_VERSION": {
+      "SchemaVersion": {
         "B": null,
         "BOOL": false,
         "IsBOOLSet": false,
@@ -150,7 +150,7 @@
     "S": null,
     "SS": []
   },
-  "LEASE_TIMEOUT": {
+  "NServiceBus_LeaseTimeout": {
     "B": null,
     "BOOL": false,
     "IsBOOLSet": false,

--- a/src/NServiceBus.Persistence.DynamoDB/Outbox/OutboxAttributeNames.cs
+++ b/src/NServiceBus.Persistence.DynamoDB/Outbox/OutboxAttributeNames.cs
@@ -2,12 +2,12 @@ namespace NServiceBus.Persistence.DynamoDB;
 
 static class OutboxAttributeNames
 {
-    public const string Dispatched = "DISPATCHED";
-    public const string DispatchedAt = "DISPATCHED_AT";
-    public const string OperationsCount = "OPERATIONS_COUNT";
-    public const string MessageId = "MESSAGE_ID";
-    public const string Properties = "PROPERTIES";
-    public const string Headers = "HEADERS";
-    public const string Body = "BODY";
-    public const string SchemaVersion = "SCHEMA_VERSION";
+    public const string Dispatched = nameof(Dispatched);
+    public const string DispatchedAt = nameof(DispatchedAt);
+    public const string OperationsCount = nameof(OperationsCount);
+    public const string MessageId = nameof(MessageId);
+    public const string Properties = nameof(Properties);
+    public const string Headers = nameof(Headers);
+    public const string Body = nameof(Body);
+    public const string SchemaVersion = nameof(SchemaVersion);
 }

--- a/src/NServiceBus.Persistence.DynamoDB/Outbox/OutboxPersister.cs
+++ b/src/NServiceBus.Persistence.DynamoDB/Outbox/OutboxPersister.cs
@@ -23,7 +23,7 @@ class OutboxPersister : IOutboxStorage
     {
         this.dynamoDbClient = dynamoDbClient;
         this.configuration = configuration;
-        this.endpointIdentifier = endpointIdentifier.ToUpperInvariant();
+        this.endpointIdentifier = endpointIdentifier;
     }
 
     public Task<IOutboxTransaction> BeginTransaction(ContextBag context,

--- a/src/NServiceBus.Persistence.DynamoDB/Saga/DeleteSagaLock.cs
+++ b/src/NServiceBus.Persistence.DynamoDB/Saga/DeleteSagaLock.cs
@@ -36,8 +36,8 @@ sealed class DeleteSagaLock : ILockCleanup
             ExpressionAttributeNames =
                 new Dictionary<string, string>
                 {
-                    { "#metadata", SagaMetadataAttributeName },
-                    { "#lease", SagaLeaseAttributeName },
+                    { "#metadata", Metadata },
+                    { "#lease", LeaseTimeout },
                 },
             ExpressionAttributeValues = new Dictionary<string, AttributeValue>
             {

--- a/src/NServiceBus.Persistence.DynamoDB/Saga/SagaMetadataAttributeNames.cs
+++ b/src/NServiceBus.Persistence.DynamoDB/Saga/SagaMetadataAttributeNames.cs
@@ -2,7 +2,9 @@ namespace NServiceBus.Persistence.DynamoDB;
 
 static class SagaMetadataAttributeNames
 {
-    public const string SagaMetadataAttributeName = "NSERVICEBUS_METADATA";
-    public const string SagaDataVersionAttributeName = "VERSION";
-    public const string SagaLeaseAttributeName = "LEASE_TIMEOUT";
+    public const string Metadata = "NServiceBus_Metadata";
+    public const string Version = "Version";
+    public const string SagaDataType = "Type";
+    public const string SchemaVersion = nameof(SchemaVersion);
+    public const string LeaseTimeout = "NServiceBus_LeaseTimeout";
 }

--- a/src/NServiceBus.Persistence.DynamoDB/Saga/UpdateSagaLock.cs
+++ b/src/NServiceBus.Persistence.DynamoDB/Saga/UpdateSagaLock.cs
@@ -38,9 +38,9 @@ sealed class UpdateSagaLock : ILockCleanup
             ExpressionAttributeNames =
                 new Dictionary<string, string>
                 {
-                    { "#metadata", SagaMetadataAttributeName },
-                    { "#lease", SagaLeaseAttributeName },
-                    { "#version", SagaDataVersionAttributeName }
+                    { "#metadata", Metadata },
+                    { "#lease", LeaseTimeout },
+                    { "#version", SagaMetadataAttributeNames.Version }
                 },
             ExpressionAttributeValues = new Dictionary<string, AttributeValue>
             {

--- a/src/NServiceBus.Persistence.DynamoDB/TableConfiguration.cs
+++ b/src/NServiceBus.Persistence.DynamoDB/TableConfiguration.cs
@@ -37,9 +37,9 @@ public record TableConfiguration
     /// The attribute name for the Time to Live setting.
     /// </summary>
     /// <remarks>
-    /// The default value is <value>"EXPIRES_AT"</value>
+    /// The default value is <value>"ExpiresAt"</value>
     /// </remarks>
-    public string? TimeToLiveAttributeName { get; set; } = "EXPIRES_AT";
+    public string? TimeToLiveAttributeName { get; set; } = "ExpiresAt";
 
     /// <summary>
     /// The billing mode for this table


### PR DESCRIPTION
As discussed it reverts part of #290 because we realized we got misguided by thinking we should apply the casing rules also to the  "userdata" parts. 

We have also concluded given the case sensitive nature of DynamoDB we don't want to do anything in the PK and SK generation that would prevent users from leveraging the case sensitive nature.