### PR TITLE
Resolve installer dynamo client from DI

### DIFF
--- a/src/NServiceBus.Persistence.DynamoDB/InstallerFeature.cs
+++ b/src/NServiceBus.Persistence.DynamoDB/InstallerFeature.cs
@@ -10,9 +10,6 @@ class InstallerFeature : Feature
         DependsOn<SynchronizedStorage>();
     }
 
-    protected override void Setup(FeatureConfigurationContext context)
-    {
-        var installer = new Installer(context.Settings.Get<IDynamoClientProvider>().Client);
-        context.Services.AddSingleton(installer);
-    }
+    protected override void Setup(FeatureConfigurationContext context) =>
+        context.Services.AddSingleton(sp => new Installer(sp.GetRequiredService<IDynamoClientProvider>().Client));
 }


### PR DESCRIPTION
This fixes a bug where the installer wouldn't use a dynamo client provided via a custom `IDynamoClientProvider` implementation and would instead fallback to the default client.