### PR TITLE
Switch outbox config to extension methods

### DIFF
--- a/src/NServiceBus.Persistence.DynamoDB.AcceptanceTests/When_installers_enabled.cs
+++ b/src/NServiceBus.Persistence.DynamoDB.AcceptanceTests/When_installers_enabled.cs
@@ -45,11 +45,7 @@ public class When_installers_enabled : NServiceBusAcceptanceTest
                 {
                     c.DisableFeature<Features.Sagas>(); // disable sagas to simulate no saga on the endpoint
                     c.ConfigureTransport().TransportTransactionMode = TransportTransactionMode.ReceiveOnly;
-                    c.EnableOutbox().UseTable(table =>
-                    {
-                        table.TableName = ctx.OutboxTableName;
-                        return table;
-                    });
+                    c.EnableOutbox().UseTable(SetupFixture.TableConfiguration with { TableName = ctx.OutboxTableName });
                 }))
             .Done(c => c.EndpointsStarted)
             .Run();
@@ -66,11 +62,7 @@ public class When_installers_enabled : NServiceBusAcceptanceTest
                 .CustomConfig((c, ctx) =>
                 {
                     c.ConfigureTransport().TransportTransactionMode = TransportTransactionMode.ReceiveOnly;
-                    c.EnableOutbox().UseTable(table =>
-                    {
-                        table.TableName = ctx.OutboxTableName;
-                        return table;
-                    });
+                    c.EnableOutbox().UseTable(SetupFixture.TableConfiguration with { TableName = ctx.OutboxTableName });
 
                     c.UsePersistence<DynamoPersistence>().DisableTablesCreation();
                 }))

--- a/src/NServiceBus.Persistence.DynamoDB.PersistenceTests/PersistenceTestsConfiguration.cs
+++ b/src/NServiceBus.Persistence.DynamoDB.PersistenceTests/PersistenceTestsConfiguration.cs
@@ -72,7 +72,7 @@ public partial class PersistenceTestsConfiguration : IDynamoClientProvider
             new OutboxPersistenceConfiguration
             {
                 Table = SetupFixture.OutboxTable,
-                TimeToLive = TimeSpan.FromSeconds(100)
+                TimeToKeepDeduplicationData = TimeSpan.FromSeconds(100)
             },
             "PersistenceTest");
 

--- a/src/NServiceBus.Persistence.DynamoDB.PessimisticLock.AcceptanceTests/ConfigureEndpointDynamoDBPersistence.cs
+++ b/src/NServiceBus.Persistence.DynamoDB.PessimisticLock.AcceptanceTests/ConfigureEndpointDynamoDBPersistence.cs
@@ -3,6 +3,7 @@ using NServiceBus;
 using NServiceBus.AcceptanceTesting.Support;
 using NServiceBus.AcceptanceTests;
 using NServiceBus.Configuration.AdvancedExtensibility;
+using NServiceBus.Persistence.DynamoDB;
 
 public class ConfigureEndpointDynamoDBPersistence : IConfigureEndpointTestExecution
 {

--- a/src/NServiceBus.Persistence.DynamoDB.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.Persistence.DynamoDB.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -28,7 +28,7 @@ namespace NServiceBus.Persistence.DynamoDB
     public static class DynamoOutboxConfigurationExtensions
     {
         public static NServiceBus.Outbox.OutboxSettings CreateTableWithInstaller(this NServiceBus.Outbox.OutboxSettings outboxSettings, bool createTable) { }
-        public static NServiceBus.Outbox.OutboxSettings SetTimeToKeepDeduplicationData(this NServiceBus.Outbox.OutboxSettings outboxSettings, System.TimeSpan timeToLive) { }
+        public static NServiceBus.Outbox.OutboxSettings SetTimeToKeepDeduplicationData(this NServiceBus.Outbox.OutboxSettings outboxSettings, System.TimeSpan timeToKeepDeduplicationData) { }
         public static NServiceBus.Outbox.OutboxSettings UseTable(this NServiceBus.Outbox.OutboxSettings outboxSettings, System.Func<NServiceBus.Persistence.DynamoDB.TableConfiguration, NServiceBus.Persistence.DynamoDB.TableConfiguration> tableConfiguration) { }
     }
     public interface IDynamoClientProvider

--- a/src/NServiceBus.Persistence.DynamoDB.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.Persistence.DynamoDB.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -7,7 +7,7 @@ namespace NServiceBus
 {
     public static class DynamoOutboxConfigurationExtensions
     {
-        public static NServiceBus.Outbox.OutboxSettings CreateTableWithInstaller(this NServiceBus.Outbox.OutboxSettings outboxSettings, bool createTable) { }
+        public static NServiceBus.Outbox.OutboxSettings CreateTable(this NServiceBus.Outbox.OutboxSettings outboxSettings, bool createTable) { }
         public static NServiceBus.Outbox.OutboxSettings SetTimeToKeepDeduplicationData(this NServiceBus.Outbox.OutboxSettings outboxSettings, System.TimeSpan timeToKeepDeduplicationData) { }
         public static NServiceBus.Outbox.OutboxSettings UseTable(this NServiceBus.Outbox.OutboxSettings outboxSettings, NServiceBus.TableConfiguration tableConfiguration) { }
     }

--- a/src/NServiceBus.Persistence.DynamoDB.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.Persistence.DynamoDB.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -29,7 +29,7 @@ namespace NServiceBus.Persistence.DynamoDB
     {
         public static NServiceBus.Outbox.OutboxSettings CreateTableWithInstaller(this NServiceBus.Outbox.OutboxSettings outboxSettings, bool createTable) { }
         public static NServiceBus.Outbox.OutboxSettings SetTimeToKeepDeduplicationData(this NServiceBus.Outbox.OutboxSettings outboxSettings, System.TimeSpan timeToKeepDeduplicationData) { }
-        public static NServiceBus.Outbox.OutboxSettings UseTable(this NServiceBus.Outbox.OutboxSettings outboxSettings, System.Func<NServiceBus.Persistence.DynamoDB.TableConfiguration, NServiceBus.Persistence.DynamoDB.TableConfiguration> tableConfiguration) { }
+        public static NServiceBus.Outbox.OutboxSettings UseTable(this NServiceBus.Outbox.OutboxSettings outboxSettings, NServiceBus.Persistence.DynamoDB.TableConfiguration tableConfiguration) { }
     }
     public interface IDynamoClientProvider
     {

--- a/src/NServiceBus.Persistence.DynamoDB.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.Persistence.DynamoDB.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -5,32 +5,59 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"NServiceBus.Persistence.DynamoDB.TransactionalSession.AcceptanceTests, PublicKey=00240000048000009400000006020000002400005253413100040000010001007f16e21368ff041183fab592d9e8ed37e7be355e93323147a1d29983d6e591b04282e4da0c9e18bd901e112c0033925eb7d7872c2f1706655891c5c9d57297994f707d16ee9a8f40d978f064ee1ffc73c0db3f4712691b23bf596f75130f4ec978cf78757ec034625a5f27e6bb50c618931ea49f6f628fd74271c32959efb1c5")]
 namespace NServiceBus
 {
+    public static class DynamoOutboxConfigurationExtensions
+    {
+        public static NServiceBus.Outbox.OutboxSettings CreateTableWithInstaller(this NServiceBus.Outbox.OutboxSettings outboxSettings, bool createTable) { }
+        public static NServiceBus.Outbox.OutboxSettings SetTimeToKeepDeduplicationData(this NServiceBus.Outbox.OutboxSettings outboxSettings, System.TimeSpan timeToKeepDeduplicationData) { }
+        public static NServiceBus.Outbox.OutboxSettings UseTable(this NServiceBus.Outbox.OutboxSettings outboxSettings, NServiceBus.TableConfiguration tableConfiguration) { }
+    }
     public class DynamoPersistence : NServiceBus.Persistence.PersistenceDefinition { }
-    public static class DynamoPersistenceConfig
+    public static class DynamoPersistenceConfigExtensions
     {
         public static void DisableTablesCreation(this NServiceBus.PersistenceExtensions<NServiceBus.DynamoPersistence> persistenceExtensions) { }
         public static NServiceBus.PersistenceExtensions<NServiceBus.DynamoPersistence> DynamoClient(this NServiceBus.PersistenceExtensions<NServiceBus.DynamoPersistence> persistenceExtensions, Amazon.DynamoDBv2.IAmazonDynamoDB dynamoClient) { }
-        public static NServiceBus.Persistence.DynamoDB.SagaPersistenceConfiguration Sagas(this NServiceBus.PersistenceExtensions<NServiceBus.DynamoPersistence> persistenceExtensions) { }
-        public static NServiceBus.PersistenceExtensions<NServiceBus.DynamoPersistence> UseSharedTable(this NServiceBus.PersistenceExtensions<NServiceBus.DynamoPersistence> persistenceExtensions, NServiceBus.Persistence.DynamoDB.TableConfiguration sharedTableConfiguration) { }
+        public static NServiceBus.PersistenceExtensions<NServiceBus.DynamoPersistence> UseSharedTable(this NServiceBus.PersistenceExtensions<NServiceBus.DynamoPersistence> persistenceExtensions, NServiceBus.TableConfiguration sharedTableConfiguration) { }
+    }
+    public static class DynamoSagaConfigurationExtensions
+    {
+        public static NServiceBus.SagaPersistenceConfiguration Sagas(this NServiceBus.PersistenceExtensions<NServiceBus.DynamoPersistence> persistenceExtensions) { }
     }
     public interface IDynamoStorageSession
     {
         void Add(Amazon.DynamoDBv2.Model.TransactWriteItem writeItem);
         void AddRange(System.Collections.Generic.IEnumerable<Amazon.DynamoDBv2.Model.TransactWriteItem> writeItems);
     }
+    public class OutboxPersistenceConfiguration
+    {
+        public OutboxPersistenceConfiguration() { }
+        public NServiceBus.TableConfiguration Table { get; set; }
+        public System.TimeSpan TimeToKeepDeduplicationData { get; set; }
+    }
+    public class SagaPersistenceConfiguration
+    {
+        public SagaPersistenceConfiguration() { }
+        public System.TimeSpan LeaseAcquisitionTimeout { get; set; }
+        public System.TimeSpan LeaseDuration { get; set; }
+        public NServiceBus.TableConfiguration Table { get; set; }
+        public bool UsePessimisticLocking { get; set; }
+    }
     public static class SynchronizedStorageSessionExtensions
     {
         public static NServiceBus.IDynamoStorageSession DynamoPersistenceSession(this NServiceBus.Persistence.ISynchronizedStorageSession session) { }
     }
+    public class TableConfiguration : System.IEquatable<NServiceBus.TableConfiguration>
+    {
+        public TableConfiguration() { }
+        public Amazon.DynamoDBv2.BillingMode BillingMode { get; set; }
+        public string PartitionKeyName { get; set; }
+        public Amazon.DynamoDBv2.Model.ProvisionedThroughput? ProvisionedThroughput { get; set; }
+        public string SortKeyName { get; set; }
+        public string TableName { get; set; }
+        public string? TimeToLiveAttributeName { get; set; }
+    }
 }
 namespace NServiceBus.Persistence.DynamoDB
 {
-    public static class DynamoOutboxConfigurationExtensions
-    {
-        public static NServiceBus.Outbox.OutboxSettings CreateTableWithInstaller(this NServiceBus.Outbox.OutboxSettings outboxSettings, bool createTable) { }
-        public static NServiceBus.Outbox.OutboxSettings SetTimeToKeepDeduplicationData(this NServiceBus.Outbox.OutboxSettings outboxSettings, System.TimeSpan timeToKeepDeduplicationData) { }
-        public static NServiceBus.Outbox.OutboxSettings UseTable(this NServiceBus.Outbox.OutboxSettings outboxSettings, NServiceBus.Persistence.DynamoDB.TableConfiguration tableConfiguration) { }
-    }
     public interface IDynamoClientProvider
     {
         Amazon.DynamoDBv2.IAmazonDynamoDB Client { get; }
@@ -42,30 +69,6 @@ namespace NServiceBus.Persistence.DynamoDB
             where TValue :  class { }
         public static object? ToObject(System.Collections.Generic.Dictionary<string, Amazon.DynamoDBv2.Model.AttributeValue> attributeValues, System.Type returnType) { }
         public static TValue? ToObject<TValue>(System.Collections.Generic.Dictionary<string, Amazon.DynamoDBv2.Model.AttributeValue> attributeValues) { }
-    }
-    public class OutboxPersistenceConfiguration
-    {
-        public OutboxPersistenceConfiguration() { }
-        public NServiceBus.Persistence.DynamoDB.TableConfiguration Table { get; set; }
-        public System.TimeSpan TimeToKeepDeduplicationData { get; set; }
-    }
-    public class SagaPersistenceConfiguration
-    {
-        public SagaPersistenceConfiguration() { }
-        public System.TimeSpan LeaseAcquisitionTimeout { get; set; }
-        public System.TimeSpan LeaseDuration { get; set; }
-        public NServiceBus.Persistence.DynamoDB.TableConfiguration Table { get; set; }
-        public bool UsePessimisticLocking { get; set; }
-    }
-    public class TableConfiguration : System.IEquatable<NServiceBus.Persistence.DynamoDB.TableConfiguration>
-    {
-        public TableConfiguration() { }
-        public Amazon.DynamoDBv2.BillingMode BillingMode { get; set; }
-        public string PartitionKeyName { get; set; }
-        public Amazon.DynamoDBv2.Model.ProvisionedThroughput? ProvisionedThroughput { get; set; }
-        public string SortKeyName { get; set; }
-        public string TableName { get; set; }
-        public string? TimeToLiveAttributeName { get; set; }
     }
 }
 namespace NServiceBus.Testing

--- a/src/NServiceBus.Persistence.DynamoDB.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.Persistence.DynamoDB.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -10,7 +10,6 @@ namespace NServiceBus
     {
         public static void DisableTablesCreation(this NServiceBus.PersistenceExtensions<NServiceBus.DynamoPersistence> persistenceExtensions) { }
         public static NServiceBus.PersistenceExtensions<NServiceBus.DynamoPersistence> DynamoClient(this NServiceBus.PersistenceExtensions<NServiceBus.DynamoPersistence> persistenceExtensions, Amazon.DynamoDBv2.IAmazonDynamoDB dynamoClient) { }
-        public static NServiceBus.Persistence.DynamoDB.OutboxPersistenceConfiguration Outbox(this NServiceBus.PersistenceExtensions<NServiceBus.DynamoPersistence> persistenceExtensions) { }
         public static NServiceBus.Persistence.DynamoDB.SagaPersistenceConfiguration Sagas(this NServiceBus.PersistenceExtensions<NServiceBus.DynamoPersistence> persistenceExtensions) { }
         public static NServiceBus.PersistenceExtensions<NServiceBus.DynamoPersistence> UseSharedTable(this NServiceBus.PersistenceExtensions<NServiceBus.DynamoPersistence> persistenceExtensions, NServiceBus.Persistence.DynamoDB.TableConfiguration sharedTableConfiguration) { }
     }
@@ -26,6 +25,12 @@ namespace NServiceBus
 }
 namespace NServiceBus.Persistence.DynamoDB
 {
+    public static class DynamoOutboxConfigurationExtensions
+    {
+        public static NServiceBus.Outbox.OutboxSettings CreateTableWithInstaller(this NServiceBus.Outbox.OutboxSettings outboxSettings, bool createTable) { }
+        public static NServiceBus.Outbox.OutboxSettings SetTimeToKeepDeduplicationData(this NServiceBus.Outbox.OutboxSettings outboxSettings, System.TimeSpan timeToLive) { }
+        public static NServiceBus.Outbox.OutboxSettings UseTable(this NServiceBus.Outbox.OutboxSettings outboxSettings, System.Func<NServiceBus.Persistence.DynamoDB.TableConfiguration, NServiceBus.Persistence.DynamoDB.TableConfiguration> tableConfiguration) { }
+    }
     public interface IDynamoClientProvider
     {
         Amazon.DynamoDBv2.IAmazonDynamoDB Client { get; }
@@ -42,7 +47,7 @@ namespace NServiceBus.Persistence.DynamoDB
     {
         public OutboxPersistenceConfiguration() { }
         public NServiceBus.Persistence.DynamoDB.TableConfiguration Table { get; set; }
-        public System.TimeSpan TimeToLive { get; set; }
+        public System.TimeSpan TimeToKeepDeduplicationData { get; set; }
     }
     public class SagaPersistenceConfiguration
     {

--- a/src/NServiceBus.Persistence.DynamoDB.Tests/OutboxSchemaVersionTests.cs
+++ b/src/NServiceBus.Persistence.DynamoDB.Tests/OutboxSchemaVersionTests.cs
@@ -4,7 +4,6 @@ using System;
 using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
-using Amazon.DynamoDBv2.Model;
 using Extensibility;
 using NUnit.Framework;
 using Outbox;

--- a/src/NServiceBus.Persistence.DynamoDB/Config/DynamoPersistenceConfig.cs
+++ b/src/NServiceBus.Persistence.DynamoDB/Config/DynamoPersistenceConfig.cs
@@ -31,7 +31,7 @@ public static class DynamoPersistenceConfig
         Guard.ThrowIfNull(sharedTableConfiguration);
 
         persistenceExtensions.Sagas().Table = sharedTableConfiguration with { };
-        persistenceExtensions.Outbox().Table = sharedTableConfiguration with { };
+        persistenceExtensions.GetSettings().GetOrCreate<OutboxPersistenceConfiguration>().Table = sharedTableConfiguration with { };
         return persistenceExtensions;
     }
 
@@ -43,16 +43,8 @@ public static class DynamoPersistenceConfig
         Guard.ThrowIfNull(persistenceExtensions);
 
         persistenceExtensions.Sagas().CreateTable = false;
-        persistenceExtensions.Outbox().CreateTable = false;
+        persistenceExtensions.GetSettings().GetOrCreate<OutboxPersistenceConfiguration>().CreateTable = false;
     }
-
-    /// <summary>
-    /// Obtains the outbox persistence configuration options.
-    /// </summary>
-    /// <param name="persistenceExtensions"></param>
-    /// <returns></returns>
-    public static OutboxPersistenceConfiguration Outbox(this PersistenceExtensions<DynamoPersistence> persistenceExtensions) =>
-        persistenceExtensions.GetSettings().GetOrCreate<OutboxPersistenceConfiguration>();
 
     /// <summary>
     /// Obtains the saga persistence configuration options.

--- a/src/NServiceBus.Persistence.DynamoDB/Config/DynamoPersistenceConfigExtensions.cs
+++ b/src/NServiceBus.Persistence.DynamoDB/Config/DynamoPersistenceConfigExtensions.cs
@@ -7,7 +7,7 @@ using Persistence.DynamoDB;
 /// <summary>
 /// Configuration extensions for DynamoDB Core API Persistence
 /// </summary>
-public static class DynamoPersistenceConfig
+public static class DynamoPersistenceConfigExtensions
 {
     /// <summary>
     /// Override the default AmazonDynamoDBClient creation by providing a pre-configured AmazonDynamoDBClient
@@ -30,7 +30,7 @@ public static class DynamoPersistenceConfig
         Guard.ThrowIfNull(persistenceExtensions);
         Guard.ThrowIfNull(sharedTableConfiguration);
 
-        persistenceExtensions.Sagas().Table = sharedTableConfiguration with { };
+        persistenceExtensions.GetSettings().GetOrCreate<SagaPersistenceConfiguration>().Table = sharedTableConfiguration with { };
         persistenceExtensions.GetSettings().GetOrCreate<OutboxPersistenceConfiguration>().Table = sharedTableConfiguration with { };
         return persistenceExtensions;
     }
@@ -42,13 +42,7 @@ public static class DynamoPersistenceConfig
     {
         Guard.ThrowIfNull(persistenceExtensions);
 
-        persistenceExtensions.Sagas().CreateTable = false;
+        persistenceExtensions.GetSettings().GetOrCreate<SagaPersistenceConfiguration>().CreateTable = false;
         persistenceExtensions.GetSettings().GetOrCreate<OutboxPersistenceConfiguration>().CreateTable = false;
     }
-
-    /// <summary>
-    /// Obtains the saga persistence configuration options.
-    /// </summary>
-    public static SagaPersistenceConfiguration Sagas(this PersistenceExtensions<DynamoPersistence> persistenceExtensions) =>
-        persistenceExtensions.GetSettings().GetOrCreate<SagaPersistenceConfiguration>();
 }

--- a/src/NServiceBus.Persistence.DynamoDB/Config/TableConfiguration.cs
+++ b/src/NServiceBus.Persistence.DynamoDB/Config/TableConfiguration.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.Persistence.DynamoDB;
+﻿namespace NServiceBus;
 
 using Amazon.DynamoDBv2;
 using Amazon.DynamoDBv2.Model;

--- a/src/NServiceBus.Persistence.DynamoDB/Outbox/DynamoOutboxConfigurationExtensions.cs
+++ b/src/NServiceBus.Persistence.DynamoDB/Outbox/DynamoOutboxConfigurationExtensions.cs
@@ -12,10 +12,12 @@ public static class DynamoOutboxConfigurationExtensions
     /// <summary>
     /// Customize the configuration of the table used by the outbox persistence.
     /// </summary>
-    public static OutboxSettings UseTable(this OutboxSettings outboxSettings, Func<TableConfiguration, TableConfiguration> tableConfiguration)
+    public static OutboxSettings UseTable(this OutboxSettings outboxSettings, TableConfiguration tableConfiguration)
     {
-        OutboxPersistenceConfiguration outboxConfiguration = outboxSettings.GetSettings().GetOrCreate<OutboxPersistenceConfiguration>();
-        outboxConfiguration.Table = tableConfiguration(outboxConfiguration.Table);
+        Guard.ThrowIfNull(outboxSettings);
+        Guard.ThrowIfNull(tableConfiguration);
+
+        outboxSettings.GetSettings().GetOrCreate<OutboxPersistenceConfiguration>().Table = tableConfiguration;
         return outboxSettings;
     }
 
@@ -35,6 +37,8 @@ public static class DynamoOutboxConfigurationExtensions
     /// </summary>
     public static OutboxSettings CreateTableWithInstaller(this OutboxSettings outboxSettings, bool createTable)
     {
+        Guard.ThrowIfNull(outboxSettings);
+
         outboxSettings.GetSettings().GetOrCreate<OutboxPersistenceConfiguration>().CreateTable = createTable;
         return outboxSettings;
     }

--- a/src/NServiceBus.Persistence.DynamoDB/Outbox/DynamoOutboxConfigurationExtensions.cs
+++ b/src/NServiceBus.Persistence.DynamoDB/Outbox/DynamoOutboxConfigurationExtensions.cs
@@ -1,8 +1,9 @@
-﻿namespace NServiceBus.Persistence.DynamoDB;
+﻿namespace NServiceBus;
 
 using System;
 using Configuration.AdvancedExtensibility;
 using Outbox;
+using Persistence.DynamoDB;
 
 /// <summary>
 /// Outbox configuration extensions for DynamoDB persistence.

--- a/src/NServiceBus.Persistence.DynamoDB/Outbox/DynamoOutboxConfigurationExtensions.cs
+++ b/src/NServiceBus.Persistence.DynamoDB/Outbox/DynamoOutboxConfigurationExtensions.cs
@@ -1,0 +1,39 @@
+﻿namespace NServiceBus.Persistence.DynamoDB;
+
+using System;
+using Configuration.AdvancedExtensibility;
+using Outbox;
+
+/// <summary>
+/// Outbox configuration extensions for DynamoDB persistence.
+/// </summary>
+public static class DynamoOutboxConfigurationExtensions
+{
+    /// <summary>
+    /// Customize the configuration of the table used by the outbox persistence.
+    /// </summary>
+    public static OutboxSettings UseTable(this OutboxSettings outboxSettings, Func<TableConfiguration, TableConfiguration> tableConfiguration)
+    {
+        OutboxPersistenceConfiguration outboxConfiguration = outboxSettings.GetSettings().GetOrCreate<OutboxPersistenceConfiguration>();
+        outboxConfiguration.Table = tableConfiguration(outboxConfiguration.Table);
+        return outboxSettings;
+    }
+
+    /// <summary>
+    /// Sets the time to live for outbox deduplication records. The default value is <value>7 days</value>.
+    /// </summary>
+    public static OutboxSettings SetTimeToKeepDeduplicationData(this OutboxSettings outboxSettings, TimeSpan timeToLive)
+    {
+        outboxSettings.GetSettings().GetOrCreate<OutboxPersistenceConfiguration>().TimeToKeepDeduplicationData = timeToLive;
+        return outboxSettings;
+    }
+
+    /// <summary>
+    /// Determines whether the NServiceBus installer should create the Outbox table when enabled. The default value is <value>true</value>.
+    /// </summary>
+    public static OutboxSettings CreateTableWithInstaller(this OutboxSettings outboxSettings, bool createTable)
+    {
+        outboxSettings.GetSettings().GetOrCreate<OutboxPersistenceConfiguration>().CreateTable = createTable;
+        return outboxSettings;
+    }
+}

--- a/src/NServiceBus.Persistence.DynamoDB/Outbox/DynamoOutboxConfigurationExtensions.cs
+++ b/src/NServiceBus.Persistence.DynamoDB/Outbox/DynamoOutboxConfigurationExtensions.cs
@@ -36,7 +36,7 @@ public static class DynamoOutboxConfigurationExtensions
     /// <summary>
     /// Determines whether the NServiceBus installer should create the Outbox table when enabled. The default value is <value>true</value>.
     /// </summary>
-    public static OutboxSettings CreateTableWithInstaller(this OutboxSettings outboxSettings, bool createTable)
+    public static OutboxSettings CreateTable(this OutboxSettings outboxSettings, bool createTable)
     {
         Guard.ThrowIfNull(outboxSettings);
 

--- a/src/NServiceBus.Persistence.DynamoDB/Outbox/DynamoOutboxConfigurationExtensions.cs
+++ b/src/NServiceBus.Persistence.DynamoDB/Outbox/DynamoOutboxConfigurationExtensions.cs
@@ -22,9 +22,11 @@ public static class DynamoOutboxConfigurationExtensions
     /// <summary>
     /// Sets the time to live for outbox deduplication records. The default value is <value>7 days</value>.
     /// </summary>
-    public static OutboxSettings SetTimeToKeepDeduplicationData(this OutboxSettings outboxSettings, TimeSpan timeToLive)
+    public static OutboxSettings SetTimeToKeepDeduplicationData(this OutboxSettings outboxSettings, TimeSpan timeToKeepDeduplicationData)
     {
-        outboxSettings.GetSettings().GetOrCreate<OutboxPersistenceConfiguration>().TimeToKeepDeduplicationData = timeToLive;
+        Guard.ThrowIfNegativeOrZero(timeToKeepDeduplicationData);
+
+        outboxSettings.GetSettings().GetOrCreate<OutboxPersistenceConfiguration>().TimeToKeepDeduplicationData = timeToKeepDeduplicationData;
         return outboxSettings;
     }
 

--- a/src/NServiceBus.Persistence.DynamoDB/Outbox/OutboxPersistenceConfiguration.cs
+++ b/src/NServiceBus.Persistence.DynamoDB/Outbox/OutboxPersistenceConfiguration.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.Persistence.DynamoDB;
+﻿namespace NServiceBus;
 
 using System;
 

--- a/src/NServiceBus.Persistence.DynamoDB/Outbox/OutboxPersistenceConfiguration.cs
+++ b/src/NServiceBus.Persistence.DynamoDB/Outbox/OutboxPersistenceConfiguration.cs
@@ -13,9 +13,9 @@ public class OutboxPersistenceConfiguration
     public TableConfiguration Table { get; set; } = new TableConfiguration();
 
     /// <summary>
-    /// The Time to Live for outbox records.
+    /// The time to live for outbox deduplication records.
     /// </summary>
-    public TimeSpan TimeToLive { get; set; } = TimeSpan.FromDays(7);
+    public TimeSpan TimeToKeepDeduplicationData { get; set; } = TimeSpan.FromDays(7);
 
     /// <summary>
     /// Determines whether the NServiceBus installer should create the Outbox table when enabled.

--- a/src/NServiceBus.Persistence.DynamoDB/Outbox/OutboxPersister.cs
+++ b/src/NServiceBus.Persistence.DynamoDB/Outbox/OutboxPersister.cs
@@ -256,7 +256,7 @@ class OutboxPersister : IOutboxStorage
         var opsCount = context.Get<int>($"dynamo_operations_count:{messageId}");
 
         var now = DateTime.UtcNow;
-        var expirationTime = now.Add(configuration.TimeToLive);
+        var expirationTime = now.Add(configuration.TimeToKeepDeduplicationData);
         int epochSeconds = AWSSDKUtils.ConvertToUnixEpochSeconds(expirationTime);
 
         var updateItem = new UpdateItemRequest

--- a/src/NServiceBus.Persistence.DynamoDB/Saga/DynamoSagaConfigurationExtensions.cs
+++ b/src/NServiceBus.Persistence.DynamoDB/Saga/DynamoSagaConfigurationExtensions.cs
@@ -1,0 +1,15 @@
+namespace NServiceBus;
+
+using Configuration.AdvancedExtensibility;
+
+/// <summary>
+/// Saga configuration extensions for DynamoDB persistence.
+/// </summary>
+public static class DynamoSagaConfigurationExtensions
+{
+    /// <summary>
+    /// Obtains the saga persistence configuration options.
+    /// </summary>
+    public static SagaPersistenceConfiguration Sagas(this PersistenceExtensions<DynamoPersistence> persistenceExtensions) =>
+        persistenceExtensions.GetSettings().GetOrCreate<SagaPersistenceConfiguration>();
+}

--- a/src/NServiceBus.Persistence.DynamoDB/Saga/SagaPersistenceConfiguration.cs
+++ b/src/NServiceBus.Persistence.DynamoDB/Saga/SagaPersistenceConfiguration.cs
@@ -1,7 +1,8 @@
-﻿namespace NServiceBus.Persistence.DynamoDB;
+﻿namespace NServiceBus;
 
 using System;
 using System.Text.Json;
+using static Persistence.DynamoDB.MapperOptions;
 
 /// <summary>
 /// The saga persistence configuration options.
@@ -36,5 +37,5 @@ public class SagaPersistenceConfiguration
     /// </summary>
     public TimeSpan LeaseAcquisitionTimeout { get; set; } = TimeSpan.FromSeconds(10);
 
-    internal JsonSerializerOptions MapperOptions { get; set; } = new(DynamoDB.MapperOptions.Defaults);
+    internal JsonSerializerOptions MapperOptions { get; set; } = new(Defaults);
 }


### PR DESCRIPTION
So that the outbox config options are exposed on the `EnableOutbox` method provided by core. This makes outbox configuration a bit easier as the user doesn't have to use two separate APIs to configure the same feature.