### PR TITLE
Mark cleanup as unnecessary when saga completed

### DIFF
--- a/src/NServiceBus.Persistence.DynamoDB/Saga/SagaPersister.cs
+++ b/src/NServiceBus.Persistence.DynamoDB/Saga/SagaPersister.cs
@@ -260,6 +260,13 @@ class SagaPersister : ISagaPersister
                 TableName = configuration.Table.TableName,
             }
         });
+
+        if (configuration.UsePessimisticLocking)
+        {
+            // we can't remove the action directly because the transaction was not completed yet
+            dynamoSession.MarkAsNoLongerNecessaryWhenSessionCommitted(lockCleanupId: sagaData.Id);
+        }
+
         return Task.CompletedTask;
     }
 


### PR DESCRIPTION
Fixes issues in pessimistic locking mode with the cleanup action failing because it would try to update the lock entry on a deleted record.

Not really sure how we could test properly for this though since we only log failures in the cleanup action but can't fail tests with it.