### PR TITLE
Remove unnecessary ExpressionAttributeNames values

### DIFF
--- a/src/NServiceBus.Persistence.DynamoDB/Outbox/OutboxPersister.cs
+++ b/src/NServiceBus.Persistence.DynamoDB/Outbox/OutboxPersister.cs
@@ -228,10 +228,6 @@ class OutboxPersister : IOutboxStorage
                         },
                         {Body, new AttributeValue {B = bodyStream}}
                     },
-                    ExpressionAttributeNames = new Dictionary<string, string>(1)
-                    {
-                        {"#SK", configuration.Table.SortKeyName}
-                    },
                     TableName = configuration.Table.TableName
                 }
             });


### PR DESCRIPTION
Since the condition check was removed when storing outbox records in #310 , the `ExpressionAttributeNames ` are no longer required.

While this doesn't seem to be an issue when running against the actual DynamoDB service, when running against DynamoDB local, the following exception is thrown:

```
Amazon.DynamoDBv2.AmazonDynamoDBException : ExpressionAttributeNames can only be specified when using expressions
  ----> Amazon.Runtime.Internal.HttpErrorResponseException : The remote server returned an error: (400) Bad Request.
  ----> System.Net.WebException : The remote server returned an error: (400) Bad Request.
```