### PR TITLE
Use C# 12 collection expressions

### DIFF
--- a/src/NServiceBus.Persistence.DynamoDB.Tests/Serialization/MapperTests.cs
+++ b/src/NServiceBus.Persistence.DynamoDB.Tests/Serialization/MapperTests.cs
@@ -637,9 +637,9 @@ public class MapperTests
 
         var classWithCyclicReference = new ClassWithCyclicReference();
 
-        reference.References = new List<ClassWithCyclicReference> { classWithCyclicReference };
+        reference.References = [classWithCyclicReference];
 
-        classWithCyclicReference.References = new List<ClassWithCyclicReference> { reference };
+        classWithCyclicReference.References = [reference];
 
         Assert.Throws<JsonException>(() => Mapper.ToMap(classWithCyclicReference));
     }
@@ -657,9 +657,9 @@ public class MapperTests
         var classWithoutCyclicReference = new ClassWithCyclicReference();
         var anotherClass = new ClassWithCyclicReference();
 
-        reference.References = new List<ClassWithCyclicReference> { classWithoutCyclicReference };
+        reference.References = [classWithoutCyclicReference];
 
-        classWithoutCyclicReference.References = new List<ClassWithCyclicReference> { anotherClass };
+        classWithoutCyclicReference.References = [anotherClass];
 
         Assert.DoesNotThrow(() => Mapper.ToMap(classWithoutCyclicReference));
     }


### PR DESCRIPTION
This change satisfies the new `IDE0028` analyzer rules in the .NET 8 SDK.