### PR TITLE
Add additional test coverage to verify sends work even when dynamosession not used

### DIFF
--- a/src/NServiceBus.Persistence.DynamoDB.TransactionalSession.AcceptanceTests/When_using_transactional_session.cs
+++ b/src/NServiceBus.Persistence.DynamoDB.TransactionalSession.AcceptanceTests/When_using_transactional_session.cs
@@ -9,6 +9,7 @@ using AcceptanceTesting;
 using AcceptanceTesting.Customization;
 using Amazon.DynamoDBv2.Model;
 using NUnit.Framework;
+using Persistence.DynamoDB;
 
 public class When_using_transactional_session : NServiceBusAcceptanceTest
 {
@@ -155,7 +156,7 @@ public class When_using_transactional_session : NServiceBusAcceptanceTest
                 },
             ExpressionAttributeValues = new Dictionary<string, AttributeValue>()
             {
-                { ":pk", new AttributeValue($"OUTBOX#{endpointIdentifier}#{messageId}") }
+                { ":pk", new AttributeValue(OutboxPersister.OutboxPartitionKey(endpointIdentifier, messageId)) }
             }
         });
         Assert.Multiple(() =>


### PR DESCRIPTION
This PR adds another test that verifies the transactional session works even when no dynamosession operations are used. The tests got added during an investigation of a potential failure, which turned out to be a misconfiguration on a DynamoDB table. 