### PR TITLE
Register missing assembly required by installer class

### DIFF
--- a/src/NServiceBus.Persistence.DynamoDB/Outbox/OutboxStorage.cs
+++ b/src/NServiceBus.Persistence.DynamoDB/Outbox/OutboxStorage.cs
@@ -3,6 +3,7 @@
 using System;
 using Features;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Outbox;
 
 sealed class OutboxStorage : Feature
@@ -23,6 +24,7 @@ sealed class OutboxStorage : Feature
 
         if (outboxConfiguration.CreateTable)
         {
+            context.Services.TryAddSingleton<Installer>();
             context.AddInstaller<OutboxInstaller>();
         }
 

--- a/src/NServiceBus.Persistence.DynamoDB/Saga/SagaStorage.cs
+++ b/src/NServiceBus.Persistence.DynamoDB/Saga/SagaStorage.cs
@@ -2,6 +2,7 @@
 
 using Features;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Sagas;
 
 sealed class SagaStorage : Feature
@@ -27,6 +28,7 @@ sealed class SagaStorage : Feature
 
         if (sagaConfiguration.CreateTable)
         {
+            context.Services.TryAddSingleton<Installer>();
             context.AddInstaller<SagaInstaller>();
         }
 


### PR DESCRIPTION
When using installers, the package fails to initialize the Outbox and Sagas installers due to a dependency that is not correctly registered in DI.

- Regression from https://github.com/Particular/NServiceBus.Persistence.DynamoDB/pull/958
- Fixes https://github.com/Particular/NServiceBus.Persistence.DynamoDB/issues/1015