### PR TITLE
Flaky test: Skip eventually consistent reads variant in outbox commit visibility test

### DIFF
--- a/src/NServiceBus.Persistence.DynamoDB.PersistenceTests/PersistenceTestsConfiguration.cs
+++ b/src/NServiceBus.Persistence.DynamoDB.PersistenceTests/PersistenceTestsConfiguration.cs
@@ -37,6 +37,8 @@ public partial class PersistenceTestsConfiguration : IDynamoClientProvider
 
     public bool SupportsPessimisticConcurrency { get; private set; }
 
+    public bool UseEventuallyConsistentReads { get; private set; }
+
     public ISagaIdGenerator SagaIdGenerator { get; } = new SagaIdGenerator();
 
     public ISagaPersister SagaStorage { get; private set; }
@@ -64,7 +66,7 @@ public partial class PersistenceTestsConfiguration : IDynamoClientProvider
 
         if (configuration.UseEventuallyConsistentReads.HasValue)
         {
-            sagaPersistenceConfiguration.UseEventuallyConsistentReads = configuration.UseEventuallyConsistentReads.Value;
+            sagaPersistenceConfiguration.UseEventuallyConsistentReads = UseEventuallyConsistentReads = configuration.UseEventuallyConsistentReads.Value;
         }
 
         SagaStorage = new SagaPersister(

--- a/src/NServiceBus.Persistence.DynamoDB.PersistenceTests/When_updating_saga_in_outbox_transaction.cs
+++ b/src/NServiceBus.Persistence.DynamoDB.PersistenceTests/When_updating_saga_in_outbox_transaction.cs
@@ -11,6 +11,8 @@ public class When_updating_saga_in_outbox_transaction : SagaPersisterTests
     public async Task Should_save_saga_only_when_outbox_tx_committed()
     {
         configuration.RequiresOptimisticConcurrencySupport();
+        Assume.That(!((PersistenceTestsConfiguration)configuration).UseEventuallyConsistentReads,
+            "Post-commit visibility cannot be asserted with eventually consistent reads.");
 
         var contextBag = configuration.GetContextBagForOutbox();
 


### PR DESCRIPTION
## Summary

- The `Should_save_saga_only_when_outbox_tx_committed` test was running against the **Optimistic Eventual Consistent** saga variant (`UseEventuallyConsistentReads: true`), which uses `ConsistentRead = false` for DynamoDB reads
- After `outboxTransaction.Commit()` (which calls `TransactWriteItemsAsync`), the immediately-following eventually-consistent `GetItem` can return `null` if a DynamoDB replica hasn't caught up yet — causing a flaky failure at line 41
- Added `Assume.That` to skip the test for that variant, since asserting immediate post-commit visibility is fundamentally incompatible with eventually consistent reads
- Also exposed `UseEventuallyConsistentReads` as a public property on `PersistenceTestsConfiguration` to enable the skip condition

## Test plan

- [ ] CI passes on Linux (previously the failing check)
- [ ] `Should_save_saga_only_when_outbox_tx_committed` now runs for Optimistic, is skipped for Optimistic Eventual Consistent, and is skipped for Pessimistic

🤖 Generated with [Claude Code](https://claude.com/claude-code)